### PR TITLE
Add ClawHub publisher abuse digest endpoint

### DIFF
--- a/src/clawhubPublisherAbuse/api.ts
+++ b/src/clawhubPublisherAbuse/api.ts
@@ -1,0 +1,386 @@
+import {
+	Container,
+	Separator,
+	TextDisplay,
+	type Client,
+	type MessagePayloadObject
+} from "@buape/carbon"
+import { formSettings } from "../../forms.config.js"
+import { getRuntimeEnv } from "../runtime/env.js"
+
+type PublisherAbuseSignal = {
+	signalId: string
+	signalType: string
+	severity: string
+	publisher: string
+	skillSlug: string
+	skillDisplayName: string | null
+	seenCount: number
+	firstSeenAt: number | null
+	lastSeenAt: number | null
+	recent7Downloads: number | null
+	recent7Installs: number | null
+	recent7InstallDownloadRatio: number | null
+	recent30Downloads: number | null
+	recent30Installs: number | null
+	recent30InstallDownloadRatio: number | null
+	allTimeDownloads: number | null
+	allTimeInstalls: number | null
+	allTimeInstallDownloadRatio: number | null
+	skillUrl: string | null
+	publisherUrl: string | null
+}
+
+type PublisherAbuseDigest = {
+	kind: "publisher_abuse_signals_changed"
+	changedCount: number
+	hasMore: boolean
+	dashboardUrl: string
+	topSignals: PublisherAbuseSignal[]
+}
+
+type PublisherAbuseDiscordMessage = {
+	components: Container[]
+	allowedMentions: NonNullable<MessagePayloadObject["allowedMentions"]>
+}
+
+type SendableChannel = {
+	send: (message: PublisherAbuseDiscordMessage) => Promise<unknown>
+}
+
+type PublisherAbuseDigestApiDependencies = {
+	token: string
+	trustedOrigins?: string[]
+	fetchChannel: (channelId: string) => Promise<unknown>
+}
+
+const apiPath = "/api/clawhub-publisher-abuse/signals/digest"
+const defaultClawHubSiteUrl = "https://clawhub.ai"
+
+const jsonResponse = (value: unknown, status = 200) =>
+	new Response(JSON.stringify(value), {
+		status,
+		headers: { "content-type": "application/json" }
+	})
+
+const bearerToken = (request: Request) =>
+	request.headers.get("authorization")?.match(/^Bearer\s+(.+)$/i)?.[1] ?? ""
+
+const readRecord = (value: unknown) =>
+	value && typeof value === "object" && !Array.isArray(value)
+		? value as Record<string, unknown>
+		: null
+
+const requiredString = (value: unknown) =>
+	typeof value === "string" && value.trim() ? value.trim() : null
+
+const optionalString = (value: unknown) =>
+	typeof value === "string" && value.trim() ? value.trim() : null
+
+const nonNegativeInteger = (value: unknown) =>
+	typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null
+
+const finiteNumber = (value: unknown) =>
+	typeof value === "number" && Number.isFinite(value) ? value : null
+
+const nonNegativeNumber = (value: unknown) => {
+	const number = finiteNumber(value)
+	return number !== null && number >= 0 ? number : null
+}
+
+const optionalNonNegativeInteger = (value: unknown) =>
+	value === undefined || value === null ? null : nonNegativeInteger(value)
+
+const optionalNonNegativeNumber = (value: unknown) =>
+	value === undefined || value === null ? null : nonNegativeNumber(value)
+
+const urlOrigin = (value: string) => {
+	try {
+		const url = new URL(value)
+		return ["http:", "https:"].includes(url.protocol) ? url.origin : null
+	} catch {
+		return null
+	}
+}
+
+export const publisherAbuseDigestTrustedOrigins = (
+	env: Pick<Env, "CLAWHUB_SITE_URL">
+) => [urlOrigin(env.CLAWHUB_SITE_URL?.trim() || defaultClawHubSiteUrl) ?? defaultClawHubSiteUrl]
+
+const trustedOriginSet = (origins: string[]) =>
+	new Set(origins.map((origin) => urlOrigin(origin.trim()) ?? origin.trim()).filter(Boolean))
+
+const validUrl = (value: unknown, trustedOrigins: ReadonlySet<string>) => {
+	const url = requiredString(value)
+	if (!url) {
+		return null
+	}
+	try {
+		const parsed = new URL(url)
+		return ["http:", "https:"].includes(parsed.protocol) && trustedOrigins.has(parsed.origin)
+			? parsed.toString()
+			: null
+	} catch {
+		return null
+	}
+}
+
+const optionalValidUrl = (value: unknown, trustedOrigins: ReadonlySet<string>) =>
+	value === undefined || value === null || value === "" ? null : validUrl(value, trustedOrigins)
+
+const invalidOptionalUrl = (rawValue: unknown, parsedValue: string | null) =>
+	rawValue !== undefined && rawValue !== null && rawValue !== "" && parsedValue === null
+
+const optionalIntegerFields = [
+	"firstSeenAt",
+	"lastSeenAt",
+	"recent7Downloads",
+	"recent7Installs",
+	"recent30Downloads",
+	"recent30Installs",
+	"allTimeDownloads",
+	"allTimeInstalls"
+]
+
+const optionalRatioFields = [
+	"recent7InstallDownloadRatio",
+	"recent30InstallDownloadRatio",
+	"allTimeInstallDownloadRatio"
+]
+
+const hasInvalidOptionalInteger = (record: Record<string, unknown>) =>
+	optionalIntegerFields.some((field) =>
+		record[field] !== undefined &&
+		record[field] !== null &&
+		nonNegativeInteger(record[field]) === null
+	)
+
+const hasInvalidOptionalRatio = (record: Record<string, unknown>) =>
+	optionalRatioFields.some((field) =>
+		record[field] !== undefined &&
+		record[field] !== null &&
+		nonNegativeNumber(record[field]) === null
+	)
+
+const parseSignal = (value: unknown, trustedOrigins: ReadonlySet<string>): PublisherAbuseSignal | null => {
+	const record = readRecord(value)
+	if (!record) {
+		return null
+	}
+
+	const signalId = requiredString(record.signalId)
+	const signalType = requiredString(record.signalType)
+	const severity = requiredString(record.severity)
+	const publisher = requiredString(record.publisher)
+	const skillSlug = requiredString(record.skillSlug)
+	const seenCount = nonNegativeInteger(record.seenCount)
+	const skillUrl = optionalValidUrl(record.skillUrl, trustedOrigins)
+	const publisherUrl = optionalValidUrl(record.publisherUrl, trustedOrigins)
+
+	if (
+		!signalId ||
+		!signalType ||
+		!severity ||
+		!publisher ||
+		!skillSlug ||
+		seenCount === null ||
+		invalidOptionalUrl(record.skillUrl, skillUrl) ||
+		invalidOptionalUrl(record.publisherUrl, publisherUrl) ||
+		hasInvalidOptionalInteger(record) ||
+		hasInvalidOptionalRatio(record)
+	) {
+		return null
+	}
+
+	return {
+		signalId,
+		signalType,
+		severity,
+		publisher,
+		skillSlug,
+		skillDisplayName: optionalString(record.skillDisplayName),
+		seenCount,
+		firstSeenAt: optionalNonNegativeInteger(record.firstSeenAt),
+		lastSeenAt: optionalNonNegativeInteger(record.lastSeenAt),
+		recent7Downloads: optionalNonNegativeInteger(record.recent7Downloads),
+		recent7Installs: optionalNonNegativeInteger(record.recent7Installs),
+		recent7InstallDownloadRatio: optionalNonNegativeNumber(record.recent7InstallDownloadRatio),
+		recent30Downloads: optionalNonNegativeInteger(record.recent30Downloads),
+		recent30Installs: optionalNonNegativeInteger(record.recent30Installs),
+		recent30InstallDownloadRatio: optionalNonNegativeNumber(record.recent30InstallDownloadRatio),
+		allTimeDownloads: optionalNonNegativeInteger(record.allTimeDownloads),
+		allTimeInstalls: optionalNonNegativeInteger(record.allTimeInstalls),
+		allTimeInstallDownloadRatio: optionalNonNegativeNumber(record.allTimeInstallDownloadRatio),
+		skillUrl,
+		publisherUrl
+	}
+}
+
+const parseDigest = (value: unknown, trustedOrigins: ReadonlySet<string>): PublisherAbuseDigest | null => {
+	const record = readRecord(value)
+	if (!record || record.kind !== "publisher_abuse_signals_changed") {
+		return null
+	}
+
+	const changedCount = nonNegativeInteger(record.changedCount)
+	const dashboardUrl = validUrl(record.dashboardUrl, trustedOrigins)
+	const topSignals = Array.isArray(record.topSignals)
+		? record.topSignals.map((signal) => parseSignal(signal, trustedOrigins))
+		: []
+
+	if (
+		changedCount === null ||
+		typeof record.hasMore !== "boolean" ||
+		!dashboardUrl ||
+		topSignals.length === 0 ||
+		topSignals.some((signal) => signal === null)
+	) {
+		return null
+	}
+
+	return {
+		kind: "publisher_abuse_signals_changed",
+		changedCount,
+		hasMore: record.hasMore,
+		dashboardUrl,
+		topSignals: topSignals.filter((signal): signal is PublisherAbuseSignal => signal !== null)
+	}
+}
+
+const isSendableChannel = (channel: unknown): channel is SendableChannel => {
+	const record = readRecord(channel)
+	return typeof record?.send === "function"
+}
+
+const plural = (count: number, singular: string, pluralValue = `${singular}s`) =>
+	count === 1 ? singular : pluralValue
+
+const reviewVerb = (count: number) => count === 1 ? "needs" : "need"
+
+const titleCaseSignalType = (signalType: string) =>
+	signalType
+		.split(/[_\s-]+/)
+		.filter(Boolean)
+		.map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+		.join(" ")
+
+const oneLineText = (value: string) =>
+	value.replace(/[\u0000-\u001f\u007f]+/g, " ").replace(/\s+/g, " ").trim()
+
+const markdownText = (value: string) =>
+	oneLineText(value).replace(/([\\`*_~|>\[\]()#])/g, "\\$1")
+
+const markdownUrl = (value: string) => {
+	const safeUrl = value.replace(/[<>]/g, (character) => character === "<" ? "%3C" : "%3E")
+	return `<${safeUrl}>`
+}
+
+const metricLine = (signal: PublisherAbuseSignal) => {
+	if (
+		signal.recent7Downloads === null ||
+		signal.recent7Installs === null ||
+		signal.recent7InstallDownloadRatio === null
+	) {
+		return null
+	}
+
+	return `7d: ${signal.recent7Installs.toLocaleString()} installs / ${signal.recent7Downloads.toLocaleString()} downloads (${(signal.recent7InstallDownloadRatio * 100).toFixed(1)}%)`
+}
+
+const signalLinks = (signal: PublisherAbuseSignal) => [
+	signal.skillUrl ? `[Skill](${markdownUrl(signal.skillUrl)})` : null,
+	signal.publisherUrl ? `[Publisher](${markdownUrl(signal.publisherUrl)})` : null
+].filter((link): link is string => Boolean(link))
+
+const signalText = (signal: PublisherAbuseSignal) => {
+	const title = markdownText(signal.skillDisplayName ?? signal.skillSlug)
+	const links = signalLinks(signal)
+	return [
+		`**${markdownText(titleCaseSignalType(signal.signalType))}** · ${markdownText(signal.severity.toUpperCase())}`,
+		`${title} · ${markdownText(signal.publisher)}/${markdownText(signal.skillSlug)}`,
+		`Seen ${signal.seenCount}x`,
+		metricLine(signal),
+		links.length ? links.join(" · ") : null
+	].filter((line): line is string => Boolean(line)).join("\n")
+}
+
+export const publisherAbuseDigestApiToken = (
+	env: Partial<Pick<Env, "CLAWHUB_BAN_APPEALS_TOKEN" | "CLAWHUB_HERMIT_TOKEN">>
+) => env.CLAWHUB_HERMIT_TOKEN?.trim() || env.CLAWHUB_BAN_APPEALS_TOKEN?.trim() || ""
+
+export const buildPublisherAbuseDigestContainer = (digest: PublisherAbuseDigest) =>
+	new Container(
+		[
+			new TextDisplay(`<@&${formSettings.clawhubAppealReviewRoleId}>`),
+			new TextDisplay("### ClawHub publisher abuse signals changed"),
+			new TextDisplay(
+				`${digest.changedCount.toLocaleString()} changed ${plural(digest.changedCount, "signal")} ${reviewVerb(digest.changedCount)} review.\n[Open ClawHub abuse signals](${markdownUrl(digest.dashboardUrl)})`
+			),
+			new Separator({ divider: true, spacing: "small" }),
+			...digest.topSignals.slice(0, 5).map((signal) => new TextDisplay(signalText(signal))),
+			...(digest.hasMore || digest.topSignals.length > 5
+				? [new TextDisplay("More signals are available in ClawHub.")]
+				: [])
+		],
+		{ accentColor: "#f2c94c" }
+	)
+
+export const handlePublisherAbuseDigestApi = async (
+	request: Request,
+	dependencies: PublisherAbuseDigestApiDependencies
+): Promise<Response | null> => {
+	const url = new URL(request.url)
+	if (url.pathname !== apiPath) {
+		return null
+	}
+	if (!dependencies.token || bearerToken(request) !== dependencies.token) {
+		return jsonResponse({ error: "Unauthorized" }, 401)
+	}
+	if (request.method !== "POST") {
+		return jsonResponse({ error: "Method not allowed" }, 405)
+	}
+
+	let body: unknown
+	try {
+		body = await request.json()
+	} catch {
+		return jsonResponse({ error: "Invalid JSON" }, 400)
+	}
+
+	const trustedOrigins = trustedOriginSet(dependencies.trustedOrigins ?? [defaultClawHubSiteUrl])
+	const digest = parseDigest(body, trustedOrigins)
+	if (!digest) {
+		return jsonResponse({ error: "Invalid publisher abuse digest payload" }, 400)
+	}
+
+	const channel = await dependencies.fetchChannel(formSettings.clawhubAppealReviewChannelId)
+	if (!isSendableChannel(channel)) {
+		throw new Error(`Review channel ${formSettings.clawhubAppealReviewChannelId} is not sendable.`)
+	}
+
+	await channel.send({
+		components: [buildPublisherAbuseDigestContainer(digest)],
+		allowedMentions: {
+			roles: [formSettings.clawhubAppealReviewRoleId],
+			users: []
+		}
+	})
+
+	return jsonResponse({
+		ok: true,
+		delivered: true,
+		changedCount: digest.changedCount
+	})
+}
+
+export const handlePublisherAbuseDigestApiRequest = (
+	request: Request,
+	client: Client
+): Promise<Response | null> => {
+	const env = getRuntimeEnv()
+	return handlePublisherAbuseDigestApi(request, {
+		token: publisherAbuseDigestApiToken(env),
+		trustedOrigins: publisherAbuseDigestTrustedOrigins(env),
+		fetchChannel: (channelId) => client.fetchChannel(channelId)
+	})
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import {
 } from "./services/nominationExpiry.js"
 import { runThreadLengthMonitor } from "./services/threadLengthMonitor.js"
 import { handleContentRightsApiRequest } from "./clawhubContentRights/api.js"
+import { handlePublisherAbuseDigestApiRequest } from "./clawhubPublisherAbuse/api.js"
 
 export const client = new Client(
 	{
@@ -122,6 +123,10 @@ export default {
 		if (contentRightsApiResponse) {
 			return contentRightsApiResponse
 		}
+		const publisherAbuseDigestResponse = await handlePublisherAbuseDigestApiRequest(request, client)
+		if (publisherAbuseDigestResponse) {
+			return publisherAbuseDigestResponse
+		}
 		const formsResponse = await handleFormsRequest(request, client)
 		if (formsResponse) {
 			return formsResponse
@@ -171,6 +176,8 @@ declare global {
 			DEVVIT_REDDIT_ACTION_URL?: string;
 			RESEND_API_KEY?: string;
 			CLAWHUB_NOREPLY_FROM?: string;
+			CLAWHUB_HERMIT_TOKEN?: string;
+			CLAWHUB_SITE_URL?: string;
 		}
 	}
 }

--- a/src/runtime/env.ts
+++ b/src/runtime/env.ts
@@ -6,6 +6,8 @@ declare global {
 		ANSWER_OVERFLOW_API_KEY: string
 		BASE_URL: string
 		CLAWHUB_BAN_APPEALS_TOKEN: string
+		CLAWHUB_HERMIT_TOKEN?: string
+		CLAWHUB_SITE_URL?: string
 		DEPLOY_SECRET: string
 		DISCORD_BOT_TOKEN: string
 		DISCORD_CLIENT_ID: string

--- a/tests/publisherAbuseDigestApi.test.ts
+++ b/tests/publisherAbuseDigestApi.test.ts
@@ -1,0 +1,505 @@
+import { describe, expect, it } from "bun:test"
+import type { Client } from "@buape/carbon"
+import {
+	handlePublisherAbuseDigestApi,
+	handlePublisherAbuseDigestApiRequest,
+	publisherAbuseDigestApiToken,
+	publisherAbuseDigestTrustedOrigins
+} from "../src/clawhubPublisherAbuse/api.js"
+import { setRuntimeEnv } from "../src/runtime/env.js"
+
+const collectText = (component: unknown): string[] => {
+	if (!component || typeof component !== "object") {
+		return []
+	}
+
+	const record = component as Record<string, unknown>
+	const content = typeof record.content === "string" ? [record.content] : []
+	const children = Array.isArray(record.components)
+		? record.components.flatMap(collectText)
+		: []
+
+	return [...content, ...children]
+}
+
+const validPayload = {
+	kind: "publisher_abuse_signals_changed",
+	changedCount: 1,
+	hasMore: false,
+	dashboardUrl: "https://clawhub.ai/management?view=abuse&tab=signals",
+	topSignals: [
+		{
+			signalId: "publisherAbuseSignals:local-loopback",
+			signalType: "high_install_download_ratio",
+			severity: "high",
+			publisher: "local-owner",
+			skillSlug: "local-skill",
+			skillDisplayName: "Local Skill",
+			seenCount: 4,
+			firstSeenAt: 1715900000000,
+			lastSeenAt: 1716000000000,
+			recent7Downloads: 1000,
+			recent7Installs: 100,
+			recent7InstallDownloadRatio: 0.1,
+			recent30Downloads: 3000,
+			recent30Installs: 300,
+			recent30InstallDownloadRatio: 0.1,
+			allTimeDownloads: 12000,
+			allTimeInstalls: 1200,
+			allTimeInstallDownloadRatio: 0.1,
+			skillUrl: "https://clawhub.ai/local-owner/skills/local-skill",
+			publisherUrl: "https://clawhub.ai/local-owner"
+		}
+	]
+}
+
+const dependencies = (options: { trustedOrigins?: string[] } = {}) => {
+	const sends: unknown[] = []
+	const fetchedChannels: string[] = []
+	return {
+		sends,
+		fetchedChannels,
+		value: {
+			token: "secret",
+			...options,
+			fetchChannel: async (channelId: string) => {
+				fetchedChannels.push(channelId)
+				return {
+					send: async (message: unknown) => {
+						sends.push(message)
+						return { id: "message-123" }
+					}
+				}
+			}
+		}
+	}
+}
+
+const clientDependencies = () => {
+	const sends: unknown[] = []
+	const fetchedChannels: string[] = []
+	const client = {
+		fetchChannel: async (channelId: string) => {
+			fetchedChannels.push(channelId)
+			return {
+				send: async (message: unknown) => {
+					sends.push(message)
+					return { id: "message-123" }
+				}
+			}
+		}
+	} as unknown as Client
+
+	return { sends, fetchedChannels, client }
+}
+
+describe("ClawHub publisher abuse digest API", () => {
+	it("prefers the dedicated ClawHub-Hermit token when configured", () => {
+		expect(publisherAbuseDigestApiToken({
+			CLAWHUB_HERMIT_TOKEN: " dedicated-token ",
+			CLAWHUB_BAN_APPEALS_TOKEN: "legacy-token"
+		})).toBe("dedicated-token")
+		expect(publisherAbuseDigestApiToken({
+			CLAWHUB_BAN_APPEALS_TOKEN: "legacy-token"
+		})).toBe("legacy-token")
+		expect(publisherAbuseDigestApiToken({
+			CLAWHUB_BAN_APPEALS_TOKEN: " fallback-token "
+		})).toBe("fallback-token")
+		expect(publisherAbuseDigestApiToken({})).toBe("")
+	})
+
+	it("builds trusted ClawHub link origins from configuration", () => {
+		expect(publisherAbuseDigestTrustedOrigins({})).toEqual(["https://clawhub.ai"])
+		expect(publisherAbuseDigestTrustedOrigins({
+			CLAWHUB_SITE_URL: " https://clawhub.example.test/management?view=abuse "
+		})).toEqual(["https://clawhub.example.test"])
+	})
+
+	it("sends a valid digest to the ClawHub review channel", async () => {
+		const deps = dependencies()
+		const response = await handlePublisherAbuseDigestApi(
+			new Request("https://forms.openclaw.ai/api/clawhub-publisher-abuse/signals/digest", {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer secret",
+					"Content-Type": "application/json"
+				},
+				body: JSON.stringify(validPayload)
+			}),
+			deps.value
+		)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({ ok: true, delivered: true, changedCount: 1 })
+		expect(deps.fetchedChannels).toEqual(["1498032057337647295"])
+		expect(deps.sends).toHaveLength(1)
+
+		const send = deps.sends[0] as { components?: unknown[]; allowedMentions?: unknown }
+		const text = (send.components ?? []).flatMap(collectText).join("\n")
+		expect(send.allowedMentions).toEqual({
+			roles: ["1509967254870298794"],
+			users: []
+		})
+		expect(text).toContain("<@&1509967254870298794>")
+		expect(text).toContain("ClawHub publisher abuse signals changed")
+		expect(text).toContain("1 changed signal needs review.")
+		expect(text).toContain("[Open ClawHub abuse signals](<https://clawhub.ai/management?view=abuse&tab=signals>)")
+		expect(text).toContain("Local Skill")
+		expect(text).toContain("local-owner/local-skill")
+		expect(text).toContain("Seen 4x")
+		expect(text).toContain("[Skill](<https://clawhub.ai/local-owner/skills/local-skill>)")
+		expect(text).toContain("[Publisher](<https://clawhub.ai/local-owner>)")
+	})
+
+	it("escapes digest text before rendering Discord markdown", async () => {
+		const deps = dependencies()
+		const response = await handlePublisherAbuseDigestApi(
+			new Request("https://forms.openclaw.ai/api/clawhub-publisher-abuse/signals/digest", {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer secret",
+					"Content-Type": "application/json"
+				},
+				body: JSON.stringify({
+					...validPayload,
+					dashboardUrl: "https://clawhub.ai/management?next=)[Dash](https://evil.example)",
+					topSignals: [
+						{
+							...validPayload.topSignals[0],
+							signalType: "high_install_download_ratio\n[extra](https://evil.example)",
+							severity: "high](https://evil.example)",
+							publisher: "local-owner\n[Publisher Trap](https://evil.example)",
+							skillSlug: "local-skill](https://evil.example)",
+							skillDisplayName: "Local Skill\n[Click](https://evil.example)",
+							skillUrl: "https://clawhub.ai/local-owner/skills/local-skill)",
+							publisherUrl: "https://clawhub.ai/local-owner)"
+						}
+					]
+				})
+			}),
+			deps.value
+		)
+
+		expect(response.status).toBe(200)
+		expect(deps.sends).toHaveLength(1)
+
+		const send = deps.sends[0] as { components?: unknown[] }
+		const text = (send.components ?? []).flatMap(collectText).join("\n")
+		expect(text).toContain("[Open ClawHub abuse signals](<https://clawhub.ai/management?next=)[Dash](https://evil.example)>)")
+		expect(text).toContain("Local Skill \\[Click\\]\\(https://evil.example\\)")
+		expect(text).toContain("local-owner \\[Publisher Trap\\]\\(https://evil.example\\)")
+		expect(text).toContain("local-skill\\]\\(https://evil.example\\)")
+		expect(text).toContain("[Skill](<https://clawhub.ai/local-owner/skills/local-skill)>)")
+		expect(text).toContain("[Publisher](<https://clawhub.ai/local-owner)>)")
+		expect(text).not.toContain("[Click](https://evil.example)")
+		expect(text).not.toContain("[Publisher Trap](https://evil.example)")
+	})
+
+	it("accepts digest links from the configured ClawHub origin", async () => {
+		const deps = dependencies({
+			trustedOrigins: publisherAbuseDigestTrustedOrigins({
+				CLAWHUB_SITE_URL: "https://clawhub.example.test"
+			})
+		})
+		const response = await handlePublisherAbuseDigestApi(
+			new Request("https://forms.openclaw.ai/api/clawhub-publisher-abuse/signals/digest", {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer secret",
+					"Content-Type": "application/json"
+				},
+				body: JSON.stringify({
+					...validPayload,
+					dashboardUrl: "https://clawhub.example.test/management?view=abuse&tab=signals",
+					topSignals: [
+						{
+							...validPayload.topSignals[0],
+							skillUrl: "https://clawhub.example.test/local-owner/skills/local-skill",
+							publisherUrl: "https://clawhub.example.test/local-owner"
+						}
+					]
+				})
+			}),
+			deps.value
+		)
+
+		expect(response.status).toBe(200)
+		expect(deps.sends).toHaveLength(1)
+
+		const send = deps.sends[0] as { components?: unknown[] }
+		const text = (send.components ?? []).flatMap(collectText).join("\n")
+		expect(text).toContain("[Open ClawHub abuse signals](<https://clawhub.example.test/management?view=abuse&tab=signals>)")
+		expect(text).toContain("[Skill](<https://clawhub.example.test/local-owner/skills/local-skill>)")
+		expect(text).toContain("[Publisher](<https://clawhub.example.test/local-owner>)")
+	})
+
+	it("shows a hint when supplied signals are locally truncated", async () => {
+		const deps = dependencies()
+		const response = await handlePublisherAbuseDigestApi(
+			new Request("https://forms.openclaw.ai/api/clawhub-publisher-abuse/signals/digest", {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer secret",
+					"Content-Type": "application/json"
+				},
+				body: JSON.stringify({
+					...validPayload,
+					changedCount: 6,
+					hasMore: false,
+					topSignals: Array.from({ length: 6 }, (_, index) => ({
+						...validPayload.topSignals[0],
+						signalId: `publisherAbuseSignals:local-${index}`,
+						skillSlug: `local-skill-${index}`,
+						skillUrl: `https://clawhub.ai/local-owner/skills/local-skill-${index}`
+					}))
+				})
+			}),
+			deps.value
+		)
+
+		expect(response.status).toBe(200)
+		expect(deps.sends).toHaveLength(1)
+
+		const send = deps.sends[0] as { components?: unknown[] }
+		const text = (send.components ?? []).flatMap(collectText).join("\n")
+		expect(text).toContain("local-owner/local-skill-4")
+		expect(text).not.toContain("local-owner/local-skill-5")
+		expect(text).toContain("More signals are available in ClawHub.")
+	})
+
+	it("passes runtime token and trusted origin into the production request wrapper", async () => {
+		setRuntimeEnv({
+			CLAWHUB_BAN_APPEALS_TOKEN: "legacy-token",
+			CLAWHUB_HERMIT_TOKEN: " dedicated-token ",
+			CLAWHUB_SITE_URL: " https://clawhub.example.test/management?view=abuse "
+		} as Env)
+		const deps = clientDependencies()
+		const response = await handlePublisherAbuseDigestApiRequest(
+			new Request("https://forms.openclaw.ai/api/clawhub-publisher-abuse/signals/digest", {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer dedicated-token",
+					"Content-Type": "application/json"
+				},
+				body: JSON.stringify({
+					...validPayload,
+					dashboardUrl: "https://clawhub.example.test/management?view=abuse&tab=signals",
+					topSignals: [
+						{
+							...validPayload.topSignals[0],
+							skillUrl: "https://clawhub.example.test/local-owner/skills/local-skill",
+							publisherUrl: "https://clawhub.example.test/local-owner"
+						}
+					]
+				})
+			}),
+			deps.client
+		)
+
+		expect(response.status).toBe(200)
+		expect(deps.fetchedChannels).toEqual(["1498032057337647295"])
+		expect(deps.sends).toHaveLength(1)
+
+		const send = deps.sends[0] as { components?: unknown[] }
+		const text = (send.components ?? []).flatMap(collectText).join("\n")
+		expect(text).toContain("[Open ClawHub abuse signals](<https://clawhub.example.test/management?view=abuse&tab=signals>)")
+		expect(text).toContain("[Skill](<https://clawhub.example.test/local-owner/skills/local-skill>)")
+		expect(text).toContain("[Publisher](<https://clawhub.example.test/local-owner>)")
+	})
+
+	it("lets unrelated routes continue when ClawHub tokens are unset", async () => {
+		setRuntimeEnv({} as Env)
+		const deps = clientDependencies()
+
+		const response = await handlePublisherAbuseDigestApiRequest(
+			new Request("https://forms.openclaw.ai/health"),
+			deps.client
+		)
+
+		expect(response).toBeNull()
+		expect(deps.fetchedChannels).toEqual([])
+		expect(deps.sends).toEqual([])
+	})
+
+	it("requires the shared ClawHub-Hermit bearer token", async () => {
+		const deps = dependencies()
+		const response = await handlePublisherAbuseDigestApi(
+			new Request("https://forms.openclaw.ai/api/clawhub-publisher-abuse/signals/digest", {
+				method: "POST",
+				body: JSON.stringify(validPayload)
+			}),
+			deps.value
+		)
+
+		expect(response.status).toBe(401)
+		expect(deps.fetchedChannels).toEqual([])
+		expect(deps.sends).toEqual([])
+	})
+
+	it("rejects authorization headers without the Bearer scheme", async () => {
+		const deps = dependencies()
+		const response = await handlePublisherAbuseDigestApi(
+			new Request("https://forms.openclaw.ai/api/clawhub-publisher-abuse/signals/digest", {
+				method: "POST",
+				headers: { Authorization: "secret" },
+				body: JSON.stringify(validPayload)
+			}),
+			deps.value
+		)
+
+		expect(response.status).toBe(401)
+		expect(deps.fetchedChannels).toEqual([])
+		expect(deps.sends).toEqual([])
+	})
+
+	it("rejects the wrong bearer token before sending to Discord", async () => {
+		const deps = dependencies()
+		const response = await handlePublisherAbuseDigestApi(
+			new Request("https://forms.openclaw.ai/api/clawhub-publisher-abuse/signals/digest", {
+				method: "POST",
+				headers: { Authorization: "Bearer wrong-secret" },
+				body: JSON.stringify(validPayload)
+			}),
+			deps.value
+		)
+
+		expect(response.status).toBe(401)
+		expect(deps.fetchedChannels).toEqual([])
+		expect(deps.sends).toEqual([])
+	})
+
+	it("rejects unsupported methods before sending to Discord", async () => {
+		const deps = dependencies()
+		const response = await handlePublisherAbuseDigestApi(
+			new Request("https://forms.openclaw.ai/api/clawhub-publisher-abuse/signals/digest", {
+				headers: { Authorization: "Bearer secret" }
+			}),
+			deps.value
+		)
+
+		expect(response.status).toBe(405)
+		expect(deps.fetchedChannels).toEqual([])
+		expect(deps.sends).toEqual([])
+	})
+
+	it("rejects invalid digest payloads before sending to Discord", async () => {
+		const deps = dependencies()
+		const response = await handlePublisherAbuseDigestApi(
+			new Request("https://forms.openclaw.ai/api/clawhub-publisher-abuse/signals/digest", {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer secret",
+					"Content-Type": "application/json"
+				},
+				body: JSON.stringify({ ...validPayload, topSignals: [] })
+			}),
+			deps.value
+		)
+
+		expect(response.status).toBe(400)
+		expect(deps.fetchedChannels).toEqual([])
+		expect(deps.sends).toEqual([])
+	})
+
+	it("rejects invalid JSON before sending to Discord", async () => {
+		const deps = dependencies()
+		const response = await handlePublisherAbuseDigestApi(
+			new Request("https://forms.openclaw.ai/api/clawhub-publisher-abuse/signals/digest", {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer secret",
+					"Content-Type": "application/json"
+				},
+				body: "{"
+			}),
+			deps.value
+		)
+
+		expect(response.status).toBe(400)
+		expect(await response.json()).toEqual({ error: "Invalid JSON" })
+		expect(deps.fetchedChannels).toEqual([])
+		expect(deps.sends).toEqual([])
+	})
+
+	it("rejects non-web digest URLs before sending to Discord", async () => {
+		const cases = [
+			{ dashboardUrl: "javascript:alert(1)" },
+			{ topSignals: [{ ...validPayload.topSignals[0], skillUrl: "javascript:alert(1)" }] },
+			{ topSignals: [{ ...validPayload.topSignals[0], publisherUrl: "ftp://clawhub.ai/local-owner" }] }
+		]
+
+		for (const payload of cases) {
+			const deps = dependencies()
+			const response = await handlePublisherAbuseDigestApi(
+				new Request("https://forms.openclaw.ai/api/clawhub-publisher-abuse/signals/digest", {
+					method: "POST",
+					headers: {
+						Authorization: "Bearer secret",
+						"Content-Type": "application/json"
+					},
+					body: JSON.stringify({ ...validPayload, ...payload })
+				}),
+				deps.value
+			)
+
+			expect(response.status).toBe(400)
+			expect(deps.fetchedChannels).toEqual([])
+			expect(deps.sends).toEqual([])
+		}
+	})
+
+	it("rejects cross-origin digest URLs before sending to Discord", async () => {
+		const cases = [
+			{ dashboardUrl: "https://evil.example/management?view=abuse&tab=signals" },
+			{ topSignals: [{ ...validPayload.topSignals[0], skillUrl: "https://evil.example/local-owner/skills/local-skill" }] },
+			{ topSignals: [{ ...validPayload.topSignals[0], publisherUrl: "https://evil.example/local-owner" }] }
+		]
+
+		for (const payload of cases) {
+			const deps = dependencies()
+			const response = await handlePublisherAbuseDigestApi(
+				new Request("https://forms.openclaw.ai/api/clawhub-publisher-abuse/signals/digest", {
+					method: "POST",
+					headers: {
+						Authorization: "Bearer secret",
+						"Content-Type": "application/json"
+					},
+					body: JSON.stringify({ ...validPayload, ...payload })
+				}),
+				deps.value
+			)
+
+			expect(response.status).toBe(400)
+			expect(deps.fetchedChannels).toEqual([])
+			expect(deps.sends).toEqual([])
+		}
+	})
+
+	it("rejects negative digest metrics before sending to Discord", async () => {
+		const cases = [
+			{ topSignals: [{ ...validPayload.topSignals[0], firstSeenAt: -1 }] },
+			{ topSignals: [{ ...validPayload.topSignals[0], recent7Downloads: -1 }] },
+			{ topSignals: [{ ...validPayload.topSignals[0], recent7Downloads: 1.5 }] },
+			{ topSignals: [{ ...validPayload.topSignals[0], recent7InstallDownloadRatio: -0.1 }] }
+		]
+
+		for (const payload of cases) {
+			const deps = dependencies()
+			const response = await handlePublisherAbuseDigestApi(
+				new Request("https://forms.openclaw.ai/api/clawhub-publisher-abuse/signals/digest", {
+					method: "POST",
+					headers: {
+						Authorization: "Bearer secret",
+						"Content-Type": "application/json"
+					},
+					body: JSON.stringify({ ...validPayload, ...payload })
+				}),
+				deps.value
+			)
+
+			expect(response.status).toBe(400)
+			expect(deps.fetchedChannels).toEqual([])
+			expect(deps.sends).toEqual([])
+		}
+	})
+})


### PR DESCRIPTION
## Summary

Hermit now accepts ClawHub publisher-abuse signal digest notifications at `POST /api/clawhub-publisher-abuse/signals/digest`. The endpoint validates a shared bearer token, checks the incoming digest shape before touching Discord, and posts a Carbon component summary into the configured ClawHub review channel.

This pairs with ClawHub PR #2927 so changed publisher-abuse signals can reach the Discord review queue from ClawHub's notification job.

## What Changed

- New authenticated receiver: only `POST /api/clawhub-publisher-abuse/signals/digest` is handled, and requests must send `Authorization: Bearer <token>`.
- Token configuration: Hermit prefers `CLAWHUB_HERMIT_TOKEN` and falls back to the existing `CLAWHUB_BAN_APPEALS_TOKEN`, matching ClawHub's sender behavior.
- Trusted ClawHub links: Hermit accepts dashboard, skill, and publisher URLs only from `CLAWHUB_SITE_URL` when configured, or `https://clawhub.ai` by default.
- Discord delivery: valid digests send one Carbon `Container` to `formSettings.clawhubAppealReviewChannelId` and allow only `formSettings.clawhubAppealReviewRoleId` to be mentioned.
- Payload guardrails: invalid auth, non-`POST` methods, invalid JSON, empty signal lists, cross-origin or non-web URLs, and malformed numeric metrics are rejected before fetching the Discord channel.

## Proof

Representative success request:

```sh
curl -i -X POST "$HERMIT_BASE_URL/api/clawhub-publisher-abuse/signals/digest" \
  -H "Authorization: Bearer <CLAWHUB_HERMIT_TOKEN>" \
  -H "Content-Type: application/json" \
  --data '{
    "kind": "publisher_abuse_signals_changed",
    "changedCount": 1,
    "hasMore": false,
    "dashboardUrl": "https://clawhub.ai/management?view=abuse&tab=signals",
    "topSignals": [
      {
        "signalId": "publisherAbuseSignals:ratio",
        "signalType": "high_install_download_ratio",
        "severity": "high",
        "publisher": "ratio-owner",
        "skillSlug": "ratio-skill",
        "skillDisplayName": "Ratio Skill",
        "seenCount": 3,
        "firstSeenAt": 1715900000000,
        "lastSeenAt": 1716000000000,
        "recent7Downloads": 800,
        "recent7Installs": 96,
        "recent7InstallDownloadRatio": 0.12,
        "recent30Downloads": 2400,
        "recent30Installs": 288,
        "recent30InstallDownloadRatio": 0.12,
        "allTimeDownloads": 10000,
        "allTimeInstalls": 1200,
        "allTimeInstallDownloadRatio": 0.12,
        "skillUrl": "https://clawhub.ai/ratio-owner/skills/ratio-skill",
        "publisherUrl": "https://clawhub.ai/ratio-owner"
      }
    ]
  }'
```

Expected response after Discord delivery:

```json
{"ok":true,"delivered":true,"changedCount":1}
```

The focused Hermit API test verifies that this request sends one Carbon component message to the ClawHub review channel, mentions only the configured review role, includes the dashboard/skill/publisher links, and shows a local truncation hint when more than five signals are supplied.

The ClawHub PR #2927 compatibility test verifies that ClawHub posts to `https://forms.example.test/api/clawhub-publisher-abuse/signals/digest` with `Authorization: Bearer hermit-token` and a `publisher_abuse_signals_changed` payload containing `changedCount`, `hasMore`, `dashboardUrl`, signal metrics, `skillUrl`, and `publisherUrl`.

No screenshots are included because this PR adds a backend integration endpoint and Discord message delivery path, not browser UI.

## Verification

Reviewer-checkable behavior:

- `bun test tests/publisherAbuseDigestApi.test.ts` passed: 17 tests, 98 assertions.
- In a checkout of ClawHub PR #2927, `bunx vitest run convex/publisherAbuse.test.ts --testNamePattern 'sends one Hermit digest for claimed changed signals'` passed: 1 test, 105 skipped.

Automated checks:

- `bun run typecheck` passed.
- `bun test` passed: 48 tests, 172 assertions.
- `git diff --check main...HEAD` passed.

Review:

- Required review model gate passed.
- Native review completed three clean passes on the final head.
- Independent cold review completed three clean passes on the final head.

Formatting note:

- `bunx prettier --check src/clawhubPublisherAbuse/api.ts src/index.ts src/runtime/env.ts tests/publisherAbuseDigestApi.test.ts` could not run because the configured package registry returned `GET https://packages.atlassian.com/artifactory/api/npm/prettier - 404`. There is no local `prettier` dependency or `format:check` script in this repo, so whitespace was checked with `git diff --check`.
