### PR TITLE
fix: accept canonical ClawHub skill URLs

### DIFF
--- a/src/clawhubContentRights/intake.ts
+++ b/src/clawhubContentRights/intake.ts
@@ -4,10 +4,12 @@ export const maxEvidenceFileBytes = 20 * 1024 * 1024
 const canonicalSkillUrl = (value: string) => {
 	const url = new URL(value)
 	const segments = url.pathname.split("/").filter(Boolean)
+	const isLegacySkillRoute = segments.length === 2
+	const isCurrentSkillRoute = segments.length === 3 && segments[1] === "skills"
 	if (
 		url.protocol !== "https:" ||
 		url.hostname !== "clawhub.ai" ||
-		segments.length !== 2
+		(!isLegacySkillRoute && !isCurrentSkillRoute)
 	) {
 		throw new Error("Every URL must identify a skill on clawhub.ai.")
 	}

--- a/tests/contentRights.test.ts
+++ b/tests/contentRights.test.ts
@@ -88,15 +88,25 @@ describe("ClawHub content rights intake", () => {
 
 	it("normalizes one or more canonical ClawHub skill URLs", () => {
 		expect(normalizeClawhubUrls(`
+			https://clawhub.ai/anysearch-ai/skills/anysearch?ref=notice
+			https://clawhub.ai/anysearch-ai/skills/anysearch-mcp/
 			https://clawhub.ai/huangrh99/xhs-mac-mcp?ref=notice
 			https://clawhub.ai/borye/xiaohongshu-mcp/
 		`)).toEqual([
+			"https://clawhub.ai/anysearch-ai/skills/anysearch",
+			"https://clawhub.ai/anysearch-ai/skills/anysearch-mcp",
 			"https://clawhub.ai/huangrh99/xhs-mac-mcp",
 			"https://clawhub.ai/borye/xiaohongshu-mcp"
 		])
 		expect(() => normalizeClawhubUrls("https://example.com/not-clawhub")).toThrow(
 			"Every URL must identify a skill on clawhub.ai."
 		)
+		expect(() => normalizeClawhubUrls("https://clawhub.ai/anysearch-ai")).toThrow(
+			"Every URL must identify a skill on clawhub.ai."
+		)
+		expect(() =>
+			normalizeClawhubUrls("https://clawhub.ai/anysearch-ai/plugins/anysearch")
+		).toThrow("Every URL must identify a skill on clawhub.ai.")
 	})
 
 	it("bounds evidence uploads and assigns a stable case id", () => {


### PR DESCRIPTION
## Summary
- accept current ClawHub skill URLs shaped as `/<owner>/skills/<slug>`
- preserve support for legacy `/<owner>/<slug>` links
- reject publisher pages and non-skill three-segment routes

## Root cause
ClawHub now redirects skill pages to `/<owner>/skills/<slug>`, while the content-rights form only accepted exactly two path segments. Canonical AnySearch links therefore failed with “Every URL must identify a skill on clawhub.ai.”

## Validation
- `bun test`
- `bun run typecheck`
- `bun run deploy:dry-run`
- autoreview: clean, no accepted/actionable findings
