### PR TITLE
Fix Discord command deployment lifecycle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { lobsterComponents } from "./components/lobsterButtons.js"
 import { slapComponents } from "./components/slapButtons.js"
 import { whoisDeleteComponents } from "./components/whoisDeleteButton.js"
 import { hydrateRuntimeEnv, type HermitEnv } from "./runtime/env.js"
+import { createCommandDeploymentTracker } from "./runtime/commandDeployment.js"
 import {
 	claimReviewComponents,
 	claimReviewModals,
@@ -58,7 +59,7 @@ export const client = new Client(
 			: process.env.DISCORD_PUBLIC_KEY,
 		token: process.env.DISCORD_BOT_TOKEN,
 		requestOptions: { queueRequests: false },
-		autoDeploy: true,
+		autoDeploy: false,
 		devGuilds: process.env.DISCORD_DEV_GUILDS?.split(",")
 	},
 	{
@@ -132,10 +133,14 @@ if (eventsRoute) {
 }
 
 const handler = createHandler(client)
+const trackCommandDeployment = createCommandDeploymentTracker(() =>
+	client.deployCommands()
+)
 
 export default {
 	async fetch(request: Request, env: HermitEnv, ctx: ExecutionContext) {
 		hydrateRuntimeEnv(env)
+		trackCommandDeployment(ctx)
 		const contentRightsApiResponse = await handleContentRightsApiRequest(request)
 		if (contentRightsApiResponse) {
 			return contentRightsApiResponse
@@ -155,6 +160,7 @@ export default {
 	},
 	scheduled(controller: ScheduledController, env: HermitEnv, ctx: ExecutionContext) {
 		hydrateRuntimeEnv(env)
+		trackCommandDeployment(ctx)
 		ctx.waitUntil(runNominationExpiry(client))
 		ctx.waitUntil(runNominationGrantRecovery(client))
 		ctx.waitUntil(runNominationCardSyncRecovery(client))

--- a/src/runtime/commandDeployment.ts
+++ b/src/runtime/commandDeployment.ts
@@ -1,0 +1,22 @@
+type CommandDeploymentContext = {
+	waitUntil(promise: Promise<unknown>): void
+}
+
+export const createCommandDeploymentTracker = (
+	deployCommands: () => Promise<unknown>
+) => {
+	let deployment: Promise<unknown> | undefined
+
+	return (context: CommandDeploymentContext) => {
+		if (!deployment) {
+			deployment = deployCommands().catch((error) => {
+				deployment = undefined
+				console.error("Failed to deploy Discord commands:", error)
+				throw error
+			})
+		}
+
+		context.waitUntil(deployment)
+		return deployment
+	}
+}

--- a/tests/commandDeployment.test.ts
+++ b/tests/commandDeployment.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, mock } from "bun:test"
+import { createCommandDeploymentTracker } from "../src/runtime/commandDeployment.js"
+
+describe("command deployment lifecycle", () => {
+	it("tracks one deployment per worker isolate", async () => {
+		const deployCommands = mock(async () => ({ usedDevGuilds: false }))
+		const tracked: Promise<unknown>[] = []
+		const trackDeployment = createCommandDeploymentTracker(deployCommands)
+		const context = {
+			waitUntil(promise: Promise<unknown>) {
+				tracked.push(promise)
+			}
+		}
+
+		const first = trackDeployment(context)
+		const second = trackDeployment(context)
+
+		expect(deployCommands).toHaveBeenCalledTimes(1)
+		expect(first).toBe(second)
+		expect(tracked).toEqual([first, first])
+		await first
+	})
+
+	it("allows a later request to retry after deployment fails", async () => {
+		const consoleError = mock(() => {})
+		const previousConsoleError = console.error
+		console.error = consoleError
+		let attempts = 0
+		const deployCommands = mock(async () => {
+			attempts += 1
+			if (attempts === 1) {
+				throw new Error("Discord unavailable")
+			}
+			return { usedDevGuilds: false }
+		})
+		const trackDeployment = createCommandDeploymentTracker(deployCommands)
+		const context = { waitUntil() {} }
+
+		try {
+			await expect(trackDeployment(context)).rejects.toThrow(
+				"Discord unavailable"
+			)
+			await expect(trackDeployment(context)).resolves.toEqual({
+				usedDevGuilds: false
+			})
+			expect(deployCommands).toHaveBeenCalledTimes(2)
+			expect(consoleError).toHaveBeenCalledTimes(1)
+		} finally {
+			console.error = previousConsoleError
+		}
+	})
+})

--- a/tests/lobsterCommand.test.ts
+++ b/tests/lobsterCommand.test.ts
@@ -643,6 +643,7 @@ describe("/lobster and Release Lobster", () => {
 		globalThis.fetch = async () => Response.json([])
 		try {
 			const { client } = await import("../src/index.js")
+			expect(client.options.autoDeploy).toBe(false)
 			expect(
 				client.commands.filter((command) =>
 					["lobster", "Release Lobster"].includes(command.name)
@@ -657,7 +658,6 @@ describe("/lobster and Release Lobster", () => {
 			expect(
 				client.componentHandler.hasComponentWithKey("lobster-butter")
 			).toBe(true)
-			await new Promise((resolve) => setTimeout(resolve, 20))
 		} finally {
 			globalThis.fetch = previousFetch
 			for (const [key, value] of Object.entries(previousEnv)) {


### PR DESCRIPTION
## What changed

- disables Carbon's detached `autoDeploy` call
- starts command synchronization from Hermit's fetch and scheduled handlers
- tracks synchronization with Cloudflare `ctx.waitUntil`
- retries synchronization on a later request after a failure
- adds focused lifecycle coverage

## Root cause

PR #21 successfully deployed the Worker, but Carbon 0.16.0 invokes `deployCommands()` from the client constructor without awaiting or tracking the promise. In a Cloudflare Worker, that work can be terminated after the request finishes, leaving Discord guild commands unchanged even though the Worker build is green.

## Impact

After this change deploys, the first Worker request or scheduled invocation will complete Discord command synchronization before Cloudflare releases the background work. This should register `/lobster` and `Release Lobster` in the configured guild.

## Validation

- `bun test` (226 passed)
- `bun run typecheck`
- `bun run deploy:dry-run`
- `git diff --check`