### PR TITLE
feat: alert on failed ClawHub signal scans

### DIFF
--- a/src/clawhubPublisherAbuse/api.ts
+++ b/src/clawhubPublisherAbuse/api.ts
@@ -39,6 +39,17 @@ type PublisherAbuseDigest = {
 	topSignals: PublisherAbuseSignal[]
 }
 
+type PublisherAbuseScanFailure = {
+	kind: "publisher_abuse_signal_scan_failed"
+	runId: string
+	failureCount: number
+	errorMessage: string
+	failedAt: number
+	dashboardUrl: string
+}
+
+type PublisherAbuseNotification = PublisherAbuseDigest | PublisherAbuseScanFailure
+
 type PublisherAbuseDiscordMessage = {
 	components: Container[]
 	allowedMentions: NonNullable<MessagePayloadObject["allowedMentions"]>
@@ -247,6 +258,40 @@ const parseDigest = (value: unknown, trustedOrigins: ReadonlySet<string>): Publi
 	}
 }
 
+const parseScanFailure = (
+	value: unknown,
+	trustedOrigins: ReadonlySet<string>
+): PublisherAbuseScanFailure | null => {
+	const record = readRecord(value)
+	if (!record || record.kind !== "publisher_abuse_signal_scan_failed") {
+		return null
+	}
+
+	const runId = requiredString(record.runId)
+	const failureCount = nonNegativeInteger(record.failureCount)
+	const errorMessage = requiredString(record.errorMessage)
+	const failedAt = nonNegativeInteger(record.failedAt)
+	const dashboardUrl = validUrl(record.dashboardUrl, trustedOrigins)
+	if (!runId || failureCount === null || failureCount === 0 || !errorMessage || failedAt === null || !dashboardUrl) {
+		return null
+	}
+
+	return {
+		kind: "publisher_abuse_signal_scan_failed",
+		runId,
+		failureCount,
+		errorMessage,
+		failedAt,
+		dashboardUrl
+	}
+}
+
+const parseNotification = (
+	value: unknown,
+	trustedOrigins: ReadonlySet<string>
+): PublisherAbuseNotification | null =>
+	parseDigest(value, trustedOrigins) ?? parseScanFailure(value, trustedOrigins)
+
 const isSendableChannel = (channel: unknown): channel is SendableChannel => {
 	const record = readRecord(channel)
 	return typeof record?.send === "function"
@@ -325,6 +370,20 @@ export const buildPublisherAbuseDigestContainer = (digest: PublisherAbuseDigest)
 		{ accentColor: "#f2c94c" }
 	)
 
+export const buildPublisherAbuseScanFailureContainer = (failure: PublisherAbuseScanFailure) =>
+	new Container(
+		[
+			new TextDisplay(`<@&${formSettings.clawhubAppealReviewRoleId}>`),
+			new TextDisplay("### ClawHub signal scan stopped"),
+			new TextDisplay(
+				`Stopped after ${failure.failureCount.toLocaleString()} failed attempts.\n[Open ClawHub abuse signals](${markdownUrl(failure.dashboardUrl)})`
+			),
+			new Separator({ divider: true, spacing: "small" }),
+			new TextDisplay(`**Run:** ${markdownText(failure.runId)}\n**Error:** ${markdownText(failure.errorMessage)}`)
+		],
+		{ accentColor: "#ef4444" }
+	)
+
 export const handlePublisherAbuseDigestApi = async (
 	request: Request,
 	dependencies: PublisherAbuseDigestApiDependencies
@@ -348,9 +407,9 @@ export const handlePublisherAbuseDigestApi = async (
 	}
 
 	const trustedOrigins = trustedOriginSet(dependencies.trustedOrigins ?? [defaultClawHubSiteUrl])
-	const digest = parseDigest(body, trustedOrigins)
-	if (!digest) {
-		return jsonResponse({ error: "Invalid publisher abuse digest payload" }, 400)
+	const notification = parseNotification(body, trustedOrigins)
+	if (!notification) {
+		return jsonResponse({ error: "Invalid publisher abuse notification payload" }, 400)
 	}
 
 	const channel = await dependencies.fetchChannel(formSettings.clawhubAppealReviewChannelId)
@@ -359,18 +418,28 @@ export const handlePublisherAbuseDigestApi = async (
 	}
 
 	await channel.send({
-		components: [buildPublisherAbuseDigestContainer(digest)],
+		components: [
+			notification.kind === "publisher_abuse_signals_changed"
+				? buildPublisherAbuseDigestContainer(notification)
+				: buildPublisherAbuseScanFailureContainer(notification)
+		],
 		allowedMentions: {
 			roles: [formSettings.clawhubAppealReviewRoleId],
 			users: []
 		}
 	})
 
-	return jsonResponse({
-		ok: true,
-		delivered: true,
-		changedCount: digest.changedCount
-	})
+	return notification.kind === "publisher_abuse_signals_changed"
+		? jsonResponse({
+			ok: true,
+			delivered: true,
+			changedCount: notification.changedCount
+		})
+		: jsonResponse({
+			ok: true,
+			delivered: true,
+			kind: notification.kind
+		})
 }
 
 export const handlePublisherAbuseDigestApiRequest = (

--- a/tests/publisherAbuseDigestApi.test.ts
+++ b/tests/publisherAbuseDigestApi.test.ts
@@ -53,6 +53,15 @@ const validPayload = {
 	]
 }
 
+const validScanFailurePayload = {
+	kind: "publisher_abuse_signal_scan_failed",
+	runId: "publisherAbuseScoreRuns:failed-run",
+	failureCount: 5,
+	errorMessage: "Query exceeded the document read limit.",
+	failedAt: 1716000000000,
+	dashboardUrl: "https://clawhub.ai/management?view=abuse&tab=signals"
+}
+
 const dependencies = (options: { trustedOrigins?: string[] } = {}) => {
 	const sends: unknown[] = []
 	const fetchedChannels: string[] = []
@@ -149,6 +158,43 @@ describe("ClawHub publisher abuse digest API", () => {
 		expect(text).toContain("Seen 4x")
 		expect(text).toContain("[Skill](<https://clawhub.ai/local-owner/skills/local-skill>)")
 		expect(text).toContain("[Publisher](<https://clawhub.ai/local-owner>)")
+	})
+
+	it("sends a terminal signal scan failure alert to the ClawHub review channel", async () => {
+		const deps = dependencies()
+		const response = await handlePublisherAbuseDigestApi(
+			new Request("https://forms.openclaw.ai/api/clawhub-publisher-abuse/signals/digest", {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer secret",
+					"Content-Type": "application/json"
+				},
+				body: JSON.stringify(validScanFailurePayload)
+			}),
+			deps.value
+		)
+
+		expect(response.status).toBe(200)
+		expect(await response.json()).toEqual({
+			ok: true,
+			delivered: true,
+			kind: "publisher_abuse_signal_scan_failed"
+		})
+		expect(deps.fetchedChannels).toEqual(["1498032057337647295"])
+		expect(deps.sends).toHaveLength(1)
+
+		const send = deps.sends[0] as { components?: unknown[]; allowedMentions?: unknown }
+		const text = (send.components ?? []).flatMap(collectText).join("\n")
+		expect(send.allowedMentions).toEqual({
+			roles: ["1509967254870298794"],
+			users: []
+		})
+		expect(text).toContain("<@&1509967254870298794>")
+		expect(text).toContain("ClawHub signal scan stopped")
+		expect(text).toContain("Stopped after 5 failed attempts")
+		expect(text).toContain("Query exceeded the document read limit.")
+		expect(text).toContain("publisherAbuseScoreRuns:failed-run")
+		expect(text).toContain("[Open ClawHub abuse signals](<https://clawhub.ai/management?view=abuse&tab=signals>)")
 	})
 
 	it("escapes digest text before rendering Discord markdown", async () => {


### PR DESCRIPTION
## Summary
- accept terminal ClawHub signal-scan failures on the existing authenticated publisher-abuse endpoint
- notify the configured ClawHub review channel and role with the run, error, and dashboard link

## Tests
- `bun test`
- `bun run typecheck`
- `bun run deploy:dry-run`
