### PR TITLE
fix(deps): keep Hermit on patched web packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "drizzle-orm": "0.45.2",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-router": "8.2.0",
+        "react-router": "8.3.0",
       },
       "devDependencies": {
         "@tailwindcss/postcss": "4.3.2",
@@ -17,7 +17,7 @@
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "drizzle-kit": "0.31.10",
-        "postcss": "8.5.16",
+        "postcss": "8.5.23",
         "postcss-cli": "11.0.1",
         "tailwindcss": "4.3.2",
         "typescript": "7.0.2",
@@ -27,6 +27,7 @@
   },
   "overrides": {
     "esbuild": "0.28.1",
+    "postcss": "8.5.23",
     "ws": "8.21.0",
   },
   "packages": {
@@ -414,7 +415,7 @@
 
     "miniflare": ["miniflare@4.20260702.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260702.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-OqX/HwWWu0JqLQ7aCQU0int9fmpMzRjVWDo0T1WJDTssYc7KlaMM3G8N8HUEunkBMflmgI8TiAqmZTISqcVmEw=="],
 
-    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
@@ -428,7 +429,7 @@
 
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
-    "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+    "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "postcss-cli": ["postcss-cli@11.0.1", "", { "dependencies": { "chokidar": "^3.3.0", "dependency-graph": "^1.0.0", "fs-extra": "^11.0.0", "picocolors": "^1.0.0", "postcss-load-config": "^5.0.0", "postcss-reporter": "^7.0.0", "pretty-hrtime": "^1.0.3", "read-cache": "^1.0.0", "slash": "^5.0.0", "tinyglobby": "^0.2.12", "yargs": "^17.0.0" }, "peerDependencies": { "postcss": "^8.0.0" }, "bin": { "postcss": "index.js" } }, "sha512-0UnkNPSayHKRe/tc2YGW6XnSqqOA9eqpiRMgRlV1S6HdGi16vwJBx7lviARzbV1HpQHqLLRH3o8vTcB0cLc+5g=="],
 
@@ -444,7 +445,7 @@
 
     "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
-    "react-router": ["react-router@8.2.0", "", { "dependencies": { "cookie-es": "^3.1.1" }, "peerDependencies": { "react": ">=19.2.7", "react-dom": ">=19.2.7" }, "optionalPeers": ["react-dom"] }, "sha512-uP1LgGNHyilL1u+ZkecQk74DJOKOb6q4NLNYLRJcD/fjoogftNb5/Rj/07o/QBFsY/5MbAKPm1peTCQuVPv9cQ=="],
+    "react-router": ["react-router@8.3.0", "", { "dependencies": { "cookie-es": "^3.1.1" }, "peerDependencies": { "react": ">=19.2.7", "react-dom": ">=19.2.7" }, "optionalPeers": ["react-dom"] }, "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ=="],
 
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"drizzle-orm": "0.45.2",
 		"react": "19.2.7",
 		"react-dom": "19.2.7",
-		"react-router": "8.2.0"
+		"react-router": "8.3.0"
 	},
 	"devDependencies": {
 		"@tailwindcss/postcss": "4.3.2",
@@ -34,7 +34,7 @@
 		"@types/react": "19.2.17",
 		"@types/react-dom": "19.2.3",
 		"drizzle-kit": "0.31.10",
-		"postcss": "8.5.16",
+		"postcss": "8.5.23",
 		"postcss-cli": "11.0.1",
 		"tailwindcss": "4.3.2",
 		"typescript": "7.0.2",
@@ -42,6 +42,7 @@
 	},
 	"overrides": {
 		"esbuild": "0.28.1",
+		"postcss": "8.5.23",
 		"ws": "8.21.0"
 	}
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves vulnerable React Router and PostCSS versions in Hermit's application and transitive build graph.

## Why This Change Was Made

React Router moves to 8.3.0 and PostCSS to 8.5.23, with a root override keeping every transitive PostCSS instance on the patched floor.

## User Impact

Hermit retains the same behavior while its routing and CSS toolchain use patched releases.

## Evidence

- TypeScript typecheck
- 255 tests passed
- targeted dependency tests: 3 passed
- autoreview: clean, no accepted/actionable findings