### PR TITLE
fix(admin): automod-bypass reports success when a Discord role change fails

### DIFF
--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -5,7 +5,9 @@ import {
 	ApplicationCommandOptionType,
 	CommandWithSubcommands,
 	PermissionFlagsBits,
-	ChannelType
+	ChannelType,
+	Container,
+	TextDisplay
 } from "@buape/carbon"
 import BaseCommand from "./base.js"
 
@@ -137,6 +139,7 @@ If there’s no response by that deadline, we’ll move forward with role remova
 export class AutomodBypassToggle extends BaseCommand {
 	name = "automod-bypass-toggle"
 	description = "Toggle automod bypass for a user"
+	ephemeral = true
 
 	options = [
 		{
@@ -169,7 +172,7 @@ export class AutomodBypassToggle extends BaseCommand {
 				await user.removeRole("1469051644024193126", "Removed automod bypass role")
 			} catch {
 				await interaction.reply({
-					content: "Failed to remove automod bypass role.",
+					components: [new Container([new TextDisplay("Failed to remove automod bypass role.")])],
 					ephemeral: true
 				})
 				return
@@ -183,7 +186,7 @@ export class AutomodBypassToggle extends BaseCommand {
 				await user.addRole("1469051644024193126", "Added automod bypass role")
 			} catch {
 				await interaction.reply({
-					content: "Failed to add automod bypass role.",
+					components: [new Container([new TextDisplay("Failed to add automod bypass role.")])],
 					ephemeral: true
 				})
 				return

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -165,13 +165,29 @@ export class AutomodBypassToggle extends BaseCommand {
 		}
 
 		if (user.roles.find(x => x.id === "1469051644024193126")) {
-			user.removeRole("1469051644024193126", "Removed automod bypass role").catch(() => { })
+			try {
+				await user.removeRole("1469051644024193126", "Removed automod bypass role")
+			} catch {
+				await interaction.reply({
+					content: "Failed to remove automod bypass role.",
+					ephemeral: true
+				})
+				return
+			}
 			await interaction.reply({
 				content: `Removed automod bypass role from <@${user.user.id}>.`,
 				ephemeral: true
 			})
 		} else {
-			user.addRole("1469051644024193126", "Added automod bypass role").catch(() => { })
+			try {
+				await user.addRole("1469051644024193126", "Added automod bypass role")
+			} catch {
+				await interaction.reply({
+					content: "Failed to add automod bypass role.",
+					ephemeral: true
+				})
+				return
+			}
 			await interaction.reply({
 				content: `Added automod bypass role to <@${user.user.id}>.`,
 				ephemeral: true

--- a/tests/adminAutomodBypass.test.ts
+++ b/tests/adminAutomodBypass.test.ts
@@ -1,109 +1,140 @@
 import { describe, expect, it } from "bun:test"
-import { type CommandInteraction } from "@buape/carbon"
-import { AutomodBypassToggle } from "../src/commands/admin.js"
+import {
+	ApplicationCommandOptionType,
+	ApplicationCommandType,
+	ApplicationIntegrationType,
+	Client,
+	ComponentType,
+	InteractionContextType,
+	InteractionResponseType,
+	InteractionType,
+	MessageFlags
+} from "@buape/carbon"
+import AdminCommand from "../src/commands/admin.js"
 
 const automodBypassRoleId = "1469051644024193126"
+const userId = "member-test"
 
-const runToggle = async (options: {
-	roleIds?: string[]
-	addRole?: (roleId: string, reason?: string) => Promise<void>
-	removeRole?: (roleId: string, reason?: string) => Promise<void>
-	userId?: string
-}) => {
-	const userId = options.userId ?? "user-123"
-	const added: Array<[string, string | undefined]> = []
-	const removed: Array<[string, string | undefined]> = []
-	const replies: Array<{ content?: string; ephemeral?: boolean }> = []
-	const member = {
-		roles: (options.roleIds ?? []).map((id) => ({ id })),
-		user: { id: userId },
-		addRole: options.addRole ?? (async (roleId: string, reason?: string) => {
-			added.push([roleId, reason])
-		}),
-		removeRole: options.removeRole ?? (async (roleId: string, reason?: string) => {
-			removed.push([roleId, reason])
-		})
-	}
-	const interaction = {
-		guild: { id: "guild-1" },
-		options: {
-			getMember: () => member
-		},
-		reply: async (payload: { content?: string; ephemeral?: boolean }) => {
-			replies.push(payload)
-		}
-	} as unknown as CommandInteraction
-
-	await new AutomodBypassToggle().run(interaction)
-
-	return { replies, added, removed, userId }
+type RestCall = {
+	method: string
+	path: string
+	body?: Record<string, unknown>
 }
 
-const replyContent = (replies: Array<{ content?: string }>) =>
-	replies.map((reply) => reply.content ?? "").join("\n")
+const startToggle = (hasRole: boolean, roleChange: () => Promise<void>) => {
+	const calls: RestCall[] = []
+	const client = new Client({
+		baseUrl: "https://example.invalid",
+		clientId: "app-test",
+		publicKey: "test-only",
+		token: "test-only",
+		disableDeployRoute: true,
+		autoDeploy: false
+	}, { commands: [new AdminCommand()] })
+	// Exercise Carbon's handler, member methods, and serializer without network calls.
+	client.rest = {
+		post: async (path: string, options: { body: Record<string, unknown> }) => {
+			calls.push({ method: "POST", path, body: options.body })
+			return {}
+		},
+		patch: async (path: string, options: { body: Record<string, unknown> }) => {
+			calls.push({ method: "PATCH", path, body: options.body })
+			return { id: "reply-test", channel_id: "channel-test" }
+		},
+		put: async (path: string) => {
+			calls.push({ method: "PUT", path })
+			await roleChange()
+		},
+		delete: async (path: string) => {
+			calls.push({ method: "DELETE", path })
+			await roleChange()
+		}
+	} as unknown as Client["rest"]
+	const running = client.commandHandler.handleCommandInteraction({
+		id: "interaction-test",
+		token: "test-only",
+		type: InteractionType.ApplicationCommand,
+		guild_id: "guild-test",
+		member: { user: { id: "staff-test", username: "staff" } },
+		data: {
+			name: "admin",
+			type: ApplicationCommandType.ChatInput,
+			options: [{
+				name: "automod-bypass-toggle",
+				type: ApplicationCommandOptionType.Subcommand,
+				options: [{ name: "user", type: ApplicationCommandOptionType.User, value: userId }]
+			}],
+			resolved: {
+				users: { [userId]: { id: userId, username: "member" } },
+				members: { [userId]: { roles: hasRole ? [automodBypassRoleId] : [] } }
+			}
+		}
+	} as Parameters<Client["commandHandler"]["handleCommandInteraction"]>[0])
+	return { calls, running }
+}
+
+const expectPrivateDefer = (calls: RestCall[]) => {
+	expect(calls[0]).toMatchObject({
+		method: "POST",
+		body: {
+			type: InteractionResponseType.DeferredChannelMessageWithSource,
+			data: { flags: MessageFlags.Ephemeral }
+		}
+	})
+}
 
 describe("/admin automod-bypass-toggle", () => {
-	it("does not claim success when addRole is rejected", async () => {
-		const { replies, userId } = await runToggle({
-			roleIds: [],
-			addRole: async () => {
+	it("keeps the parent admin command guild-only", () => {
+		const command = new AdminCommand().serialize()
+		expect(command.integration_types).toEqual([ApplicationIntegrationType.GuildInstall])
+		expect(command.contexts).toEqual([InteractionContextType.Guild])
+	})
+
+	for (const hasRole of [false, true]) {
+		const verb = hasRole ? "remove" : "add"
+		const method = hasRole ? "DELETE" : "PUT"
+
+		it(`reports ${verb}Role rejection privately with Carbon components`, async () => {
+			const { calls, running } = startToggle(hasRole, async () => {
 				throw new Error("Missing Permissions")
-			}
+			})
+			await running
+
+			expectPrivateDefer(calls)
+			expect(calls.map(call => call.method)).toEqual(["POST", method, "PATCH"])
+			expect(calls[1]?.path).toBe(`/guilds/guild-test/members/${userId}/roles/${automodBypassRoleId}`)
+			expect(calls[2]?.body).toMatchObject({
+				flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
+				components: [{
+					type: ComponentType.Container,
+					components: [{ type: ComponentType.TextDisplay, content: `Failed to ${verb} automod bypass role.` }]
+				}]
+			})
+			expect(calls[2]?.body?.content).toBeUndefined()
 		})
 
-		expect(replies).toHaveLength(1)
-		expect(replies[0]?.ephemeral).toBe(true)
-		expect(replyContent(replies)).not.toContain(
-			`Added automod bypass role to <@${userId}>.`
-		)
-		expect(replyContent(replies).toLowerCase()).toContain("failed")
-	})
+		it(`reports success only after ${verb}Role resolves`, async () => {
+			let resolveRole!: () => void
+			let markRoleStarted!: () => void
+			const roleStarted = new Promise<void>(resolve => { markRoleStarted = resolve })
+			const roleChange = new Promise<void>(resolve => { resolveRole = resolve })
+			const { calls, running } = startToggle(hasRole, async () => {
+				markRoleStarted()
+				await roleChange
+			})
+			await roleStarted
 
-	it("does not claim success when removeRole is rejected", async () => {
-		const { replies, userId } = await runToggle({
-			roleIds: [automodBypassRoleId],
-			removeRole: async () => {
-				throw new Error("Missing Permissions")
-			}
+			expectPrivateDefer(calls)
+			expect(calls.map(call => call.method)).toEqual(["POST", method])
+			resolveRole()
+			await running
+			expect(calls.map(call => call.method)).toEqual(["POST", method, "PATCH"])
+			expect(calls[2]?.body).toMatchObject({
+				content: hasRole
+					? `Removed automod bypass role from <@${userId}>.`
+					: `Added automod bypass role to <@${userId}>.`,
+				flags: MessageFlags.Ephemeral
+			})
 		})
-
-		expect(replies).toHaveLength(1)
-		expect(replies[0]?.ephemeral).toBe(true)
-		expect(replyContent(replies)).not.toContain(
-			`Removed automod bypass role from <@${userId}>.`
-		)
-		expect(replyContent(replies).toLowerCase()).toContain("failed")
-	})
-
-	it("reports success only after addRole resolves", async () => {
-		const { replies, added, userId } = await runToggle({
-			roleIds: []
-		})
-
-		expect(added).toEqual([
-			[automodBypassRoleId, "Added automod bypass role"]
-		])
-		expect(replies).toEqual([
-			{
-				content: `Added automod bypass role to <@${userId}>.`,
-				ephemeral: true
-			}
-		])
-	})
-
-	it("reports success only after removeRole resolves", async () => {
-		const { replies, removed, userId } = await runToggle({
-			roleIds: [automodBypassRoleId]
-		})
-
-		expect(removed).toEqual([
-			[automodBypassRoleId, "Removed automod bypass role"]
-		])
-		expect(replies).toEqual([
-			{
-				content: `Removed automod bypass role from <@${userId}>.`,
-				ephemeral: true
-			}
-		])
-	})
+	}
 })

--- a/tests/adminAutomodBypass.test.ts
+++ b/tests/adminAutomodBypass.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "bun:test"
+import { type CommandInteraction } from "@buape/carbon"
+import { AutomodBypassToggle } from "../src/commands/admin.js"
+
+const automodBypassRoleId = "1469051644024193126"
+
+const runToggle = async (options: {
+	roleIds?: string[]
+	addRole?: (roleId: string, reason?: string) => Promise<void>
+	removeRole?: (roleId: string, reason?: string) => Promise<void>
+	userId?: string
+}) => {
+	const userId = options.userId ?? "user-123"
+	const added: Array<[string, string | undefined]> = []
+	const removed: Array<[string, string | undefined]> = []
+	const replies: Array<{ content?: string; ephemeral?: boolean }> = []
+	const member = {
+		roles: (options.roleIds ?? []).map((id) => ({ id })),
+		user: { id: userId },
+		addRole: options.addRole ?? (async (roleId: string, reason?: string) => {
+			added.push([roleId, reason])
+		}),
+		removeRole: options.removeRole ?? (async (roleId: string, reason?: string) => {
+			removed.push([roleId, reason])
+		})
+	}
+	const interaction = {
+		guild: { id: "guild-1" },
+		options: {
+			getMember: () => member
+		},
+		reply: async (payload: { content?: string; ephemeral?: boolean }) => {
+			replies.push(payload)
+		}
+	} as unknown as CommandInteraction
+
+	await new AutomodBypassToggle().run(interaction)
+
+	return { replies, added, removed, userId }
+}
+
+const replyContent = (replies: Array<{ content?: string }>) =>
+	replies.map((reply) => reply.content ?? "").join("\n")
+
+describe("/admin automod-bypass-toggle", () => {
+	it("does not claim success when addRole is rejected", async () => {
+		const { replies, userId } = await runToggle({
+			roleIds: [],
+			addRole: async () => {
+				throw new Error("Missing Permissions")
+			}
+		})
+
+		expect(replies).toHaveLength(1)
+		expect(replies[0]?.ephemeral).toBe(true)
+		expect(replyContent(replies)).not.toContain(
+			`Added automod bypass role to <@${userId}>.`
+		)
+		expect(replyContent(replies).toLowerCase()).toContain("failed")
+	})
+
+	it("does not claim success when removeRole is rejected", async () => {
+		const { replies, userId } = await runToggle({
+			roleIds: [automodBypassRoleId],
+			removeRole: async () => {
+				throw new Error("Missing Permissions")
+			}
+		})
+
+		expect(replies).toHaveLength(1)
+		expect(replies[0]?.ephemeral).toBe(true)
+		expect(replyContent(replies)).not.toContain(
+			`Removed automod bypass role from <@${userId}>.`
+		)
+		expect(replyContent(replies).toLowerCase()).toContain("failed")
+	})
+
+	it("reports success only after addRole resolves", async () => {
+		const { replies, added, userId } = await runToggle({
+			roleIds: []
+		})
+
+		expect(added).toEqual([
+			[automodBypassRoleId, "Added automod bypass role"]
+		])
+		expect(replies).toEqual([
+			{
+				content: `Added automod bypass role to <@${userId}>.`,
+				ephemeral: true
+			}
+		])
+	})
+
+	it("reports success only after removeRole resolves", async () => {
+		const { replies, removed, userId } = await runToggle({
+			roleIds: [automodBypassRoleId]
+		})
+
+		expect(removed).toEqual([
+			[automodBypassRoleId, "Removed automod bypass role"]
+		])
+		expect(replies).toEqual([
+			{
+				content: `Removed automod bypass role from <@${userId}>.`,
+				ephemeral: true
+			}
+		])
+	})
+})


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `/admin automod-bypass-toggle` reported that a role was added or removed even when Discord rejected the change.

## Why This Change Was Made

The command awaits the role update and returns a Carbon v2 error response if it fails. Success is reported only after Discord accepts the update. The initial interaction defer is now ephemeral, so the later response is private as intended.

## User Impact

Admins receive an accurate, private result for both adding and removing automod bypass. The command remains guild-only.

## Evidence

- Five focused tests exercise the actual Carbon command handler, GuildMember methods, and message serializer through a local REST transport. They verify both failures, delayed-success ordering, private initial defer, and guild-only registration.
- Focused tests and typecheck pass on the PR branch and when combined with current main and #27.
- [Full CI](https://github.com/openclaw/hermit/actions/runs/34280591806) covers frozen installs, Worker and forwarder typechecks, a dry-run build, and the full suite.
- Local verification used synthetic identities and no live Discord requests.
