### PR TITLE
fix(admin): surface inactivity-warn thread addMember failures

### DIFF
--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -5,7 +5,9 @@ import {
 	ApplicationCommandOptionType,
 	CommandWithSubcommands,
 	PermissionFlagsBits,
-	ChannelType
+	ChannelType,
+	Container,
+	TextDisplay
 } from "@buape/carbon"
 import BaseCommand from "./base.js"
 
@@ -134,7 +136,11 @@ If there’s no response by that deadline, we’ll move forward with role remova
 
 		if (addMemberFailed) {
 			await interaction.reply({
-				content: `Created inactivity warning thread for <@${user.id}> in <#${inactivityWarnChannel}>. Failed to add you to the thread.`,
+				components: [
+					new Container([
+						new TextDisplay(`Created inactivity warning thread for <@${user.id}> in <#${inactivityWarnChannel}>. Failed to add you to the thread.`)
+					])
+				],
 				ephemeral: true
 			})
 			return

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -107,8 +107,13 @@ export class InactivityWarn extends BaseCommand {
 			type: ChannelType.PrivateThread
 		})
 		const actorId = interaction.user?.id ?? interaction.userId
+		let addMemberFailed = false
 		if (actorId) {
-			await thread.addMember(actorId).catch(() => { })
+			try {
+				await thread.addMember(actorId)
+			} catch {
+				addMemberFailed = true
+			}
 		}
 
 		const deadline = Math.floor((Date.now() + 2 * 24 * 60 * 60 * 1000) / 1000)
@@ -126,6 +131,14 @@ Please reply in this channel by <t:${deadline}:F> (<t:${deadline}:R>) and confir
 If you need time away, post an LOA in your team channel (dates) and ${leadLine}
 
 If there’s no response by that deadline, we’ll move forward with role removal.`)
+
+		if (addMemberFailed) {
+			await interaction.reply({
+				content: `Created inactivity warning thread for <@${user.id}> in <#${inactivityWarnChannel}>. Failed to add you to the thread.`,
+				ephemeral: true
+			})
+			return
+		}
 
 		await interaction.reply({
 			content: `Created inactivity warning thread for <@${user.id}> in <#${inactivityWarnChannel}>.`,

--- a/tests/adminInactivityWarn.test.ts
+++ b/tests/adminInactivityWarn.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test"
+import { ChannelType, type CommandInteraction } from "@buape/carbon"
+import { InactivityWarn } from "../src/commands/admin.js"
+
+const inactivityWarnChannel = "1477357508833185954"
+
+const runWarn = async (options: {
+	addMember?: (userId: string) => Promise<void>
+	userId?: string
+	actorId?: string
+	username?: string
+}) => {
+	const userId = options.userId ?? "user-123"
+	const actorId = options.actorId ?? "staff-456"
+	const username = options.username ?? "warned-user"
+	const addedMembers: string[] = []
+	const sent: string[] = []
+	const threadStarts: unknown[] = []
+	const replies: Array<{ content?: string; ephemeral?: boolean }> = []
+
+	const thread = {
+		addMember: options.addMember ?? (async (id: string) => {
+			addedMembers.push(id)
+		}),
+		send: async (content: string) => {
+			sent.push(content)
+		}
+	}
+
+	const channel = {
+		type: ChannelType.GuildText,
+		startThread: async (payload: unknown) => {
+			threadStarts.push(payload)
+			return thread
+		}
+	}
+
+	const interaction = {
+		guild: { id: "guild-1" },
+		user: { id: actorId },
+		userId: actorId,
+		options: {
+			getUser: () => ({ id: userId, username }),
+			getMentionable: () => null
+		},
+		client: {
+			fetchChannel: async () => channel
+		},
+		reply: async (payload: { content?: string; ephemeral?: boolean }) => {
+			replies.push(payload)
+		}
+	} as unknown as CommandInteraction
+
+	await new InactivityWarn().run(interaction)
+
+	return { replies, addedMembers, sent, threadStarts, userId, actorId }
+}
+
+const replyContent = (replies: Array<{ content?: string }>) =>
+	replies.map((reply) => reply.content ?? "").join("\n")
+
+describe("/admin inactivity-warn", () => {
+	it("does not claim unqualified success when addMember is rejected", async () => {
+		const { replies, sent, threadStarts, userId } = await runWarn({
+			addMember: async () => {
+				throw new Error("Missing Permissions")
+			}
+		})
+
+		expect(threadStarts).toHaveLength(1)
+		expect(sent).toHaveLength(1)
+		expect(replies).toHaveLength(1)
+		expect(replies[0]?.ephemeral).toBe(true)
+		expect(replyContent(replies)).not.toBe(
+			`Created inactivity warning thread for <@${userId}> in <#${inactivityWarnChannel}>.`
+		)
+		expect(replyContent(replies).toLowerCase()).toContain("failed")
+		expect(replyContent(replies)).toContain(
+			`Created inactivity warning thread for <@${userId}>`
+		)
+	})
+
+	it("reports created thread after addMember resolves", async () => {
+		const { replies, addedMembers, sent, userId, actorId } = await runWarn({})
+
+		expect(addedMembers).toEqual([actorId])
+		expect(sent).toHaveLength(1)
+		expect(replies).toEqual([
+			{
+				content: `Created inactivity warning thread for <@${userId}> in <#${inactivityWarnChannel}>.`,
+				ephemeral: true
+			}
+		])
+	})
+})

--- a/tests/adminInactivityWarn.test.ts
+++ b/tests/adminInactivityWarn.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test"
-import { ChannelType, type CommandInteraction } from "@buape/carbon"
+import {
+	ChannelType,
+	ComponentType,
+	MessageFlags,
+	serializePayload,
+	type CommandInteraction,
+	type MessagePayloadObject
+} from "@buape/carbon"
 import { InactivityWarn } from "../src/commands/admin.js"
 
 const inactivityWarnChannel = "1477357508833185954"
@@ -16,7 +23,7 @@ const runWarn = async (options: {
 	const addedMembers: string[] = []
 	const sent: string[] = []
 	const threadStarts: unknown[] = []
-	const replies: Array<{ content?: string; ephemeral?: boolean }> = []
+	const replies: MessagePayloadObject[] = []
 
 	const thread = {
 		addMember: options.addMember ?? (async (id: string) => {
@@ -46,7 +53,7 @@ const runWarn = async (options: {
 		client: {
 			fetchChannel: async () => channel
 		},
-		reply: async (payload: { content?: string; ephemeral?: boolean }) => {
+		reply: async (payload: MessagePayloadObject) => {
 			replies.push(payload)
 		}
 	} as unknown as CommandInteraction
@@ -55,9 +62,6 @@ const runWarn = async (options: {
 
 	return { replies, addedMembers, sent, threadStarts, userId, actorId }
 }
-
-const replyContent = (replies: Array<{ content?: string }>) =>
-	replies.map((reply) => reply.content ?? "").join("\n")
 
 describe("/admin inactivity-warn", () => {
 	it("does not claim unqualified success when addMember is rejected", async () => {
@@ -71,13 +75,20 @@ describe("/admin inactivity-warn", () => {
 		expect(sent).toHaveLength(1)
 		expect(replies).toHaveLength(1)
 		expect(replies[0]?.ephemeral).toBe(true)
-		expect(replyContent(replies)).not.toBe(
-			`Created inactivity warning thread for <@${userId}> in <#${inactivityWarnChannel}>.`
-		)
-		expect(replyContent(replies).toLowerCase()).toContain("failed")
-		expect(replyContent(replies)).toContain(
-			`Created inactivity warning thread for <@${userId}>`
-		)
+		const payload = serializePayload(replies[0]!)
+		expect(payload.content).toBeUndefined()
+		expect(payload.flags).toBe(MessageFlags.Ephemeral | MessageFlags.IsComponentsV2)
+		expect(payload.components).toMatchObject([
+			{
+				type: ComponentType.Container,
+				components: [
+					{
+						type: ComponentType.TextDisplay,
+						content: `Created inactivity warning thread for <@${userId}> in <#${inactivityWarnChannel}>. Failed to add you to the thread.`
+					}
+				]
+			}
+		])
 	})
 
 	it("reports created thread after addMember resolves", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `/admin inactivity-warn` reported complete success after Discord failed to add the invoking moderator to the private warning thread.

## Why This Change Was Made

The command awaits `thread.addMember`. If membership fails, the private Carbon v2 response explains that the thread was created but the moderator could not be added. The successful membership path retains its normal confirmation.

## User Impact

Moderators can tell when a warning thread exists but they were not added to it, instead of assuming the entire operation succeeded.

## Evidence

- Both focused tests pass, covering successful membership and the partial-failure response. Failure coverage checks the serialized Carbon Container/TextDisplay and ephemeral/components-v2 flags.
- Typecheck passes, including a combined integration with main and #26.
- [Full CI](https://github.com/openclaw/hermit/actions/runs/34280594131) covers frozen installs, Worker and forwarder typechecks, a dry-run build, and the full suite.
- Local verification used synthetic data and no live Discord requests.
