### PR TITLE
ci: run build and test gates for both Bun packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check:
+    name: Build and test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      WRANGLER_SEND_METRICS: "false"
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.4.0"
+
+      - name: Install artwork test tools
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          brew install imagemagick webp
+          echo "$(brew --prefix)/bin" >> "$GITHUB_PATH"
+
+      - name: Install Worker dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install forwarder dependencies
+        working-directory: forwarder
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck Worker
+        run: bun run typecheck
+
+      - name: Typecheck forwarder
+        working-directory: forwarder
+        run: bun run typecheck
+
+      - name: Build Worker without deploying
+        run: bun run deploy:dry-run
+
+      - name: Run full test suite
+        run: bun run test

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ bun run dev
 
 ## CI/CD
 
+GitHub Actions runs frozen installs and typechecks for both Bun packages, a Worker dry-run build, and the full test suite on pull requests and pushes to `main`. These checks share one Ubuntu job with a 20-minute timeout; CI installs ImageMagick 7 and the WebP tools needed by the artwork tests. The workflow does not deploy or require deployment secrets.
+
 Cloudflare Workers Builds deploys pushes to `main`. The deploy command should apply D1 migrations before deploying the Worker:
 
 ```bash


### PR DESCRIPTION
## What Problem This Solves

Hermit currently has security and dispatch checks, but no GitHub Actions gate for dependency installation, typechecking, building, or tests. The dependency update in #31 was validated locally; future changes need the same checks on pull requests and pushes to `main`.

## Why This Change Was Made

Adds one `Build and test` job on Ubuntu 24.04 with a 20-minute timeout. It frozen-installs the Worker and forwarder packages, typechecks both, builds the Worker with `deploy:dry-run`, and runs the complete test suite. The artwork corpus tests stay in that single job with their existing assertions and timeouts.

The workflow follows the sibling `openclaw/lobster` CI permissions/concurrency pattern and pins checkout, Node setup, and Bun setup actions to full commit SHAs. Checkout does not persist credentials. It selects Node 24 and Bun 1.4.0, and installs ImageMagick 7 and WebP tools through the runner's preinstalled Homebrew because the tests require the `magick` command.

## User Impact

Pull requests and pushes to `main` gain a reproducible build/test check. The README documents the coverage. No deployment secrets, production migrations, or deployments are used; Cloudflare Builds remains responsible for production deployment.

## Evidence

- `actionlint` 1.7.12: all repository workflows pass.
- `git diff --check`: passes.
- Required Codex review: completed with no actionable blockers.
- [CI run 33188726254](https://github.com/openclaw/hermit/actions/runs/33188726254): **passed on the first attempt**, with the single job completing in **2m 25s**. Both frozen installs, both typechecks, and the Worker dry-run build passed.
- Full test suite on GitHub: **255 passed, 0 failed, 184,703 assertions across 28 files in 102.04 seconds**. No tests were skipped or sharded.
- Worker dry-run bundle: 7,405.88 KiB raw / 645.52 KiB gzip; nothing deployed.

Related: #31
