### PR TITLE
fix(claim): do not report accept when decision persist fails

### DIFF
--- a/src/server/claimServer.ts
+++ b/src/server/claimServer.ts
@@ -200,14 +200,30 @@ class ClaimReviewAcceptButton extends Button {
 			return
 		}
 
-		await recordClaimDecision({
-			userId,
-			guildId,
-			status: "accepted",
-			decidedById: interaction.user?.id
-		}).catch((error) => {
+		try {
+			await recordClaimDecision({
+				userId,
+				guildId,
+				status: "accepted",
+				decidedById: interaction.user?.id
+			})
+		} catch (error) {
 			console.error("Failed to record accepted claim:", error)
-		})
+			await interaction.reply({
+				components: [
+					new Container(
+						[
+							new TextDisplay("### Could not record claim"),
+							new TextDisplay(
+								"The clawtributors role was added, but the claim decision could not be saved. Ask a moderator to retry or update the claim record."
+							)
+						],
+						{ accentColor: "#f85149" }
+					)
+				]
+			})
+			return
+		}
 
 		const user = await interaction.client.fetchUser(userId).catch(() => null)
 		await user?.send({

--- a/tests/claimAcceptPersist.test.ts
+++ b/tests/claimAcceptPersist.test.ts
@@ -1,0 +1,126 @@
+import { type ButtonInteraction, serializePayload } from "@buape/carbon"
+import { describe, expect, it, spyOn } from "bun:test"
+import * as claimRequests from "../src/data/claimRequests.js"
+import { setRuntimeEnv } from "../src/runtime/env.js"
+import { claimReviewComponents } from "../src/server/claimServer.js"
+
+const flattenComponents = (component: unknown): Record<string, unknown>[] => {
+	if (!component || typeof component !== "object") {
+		return []
+	}
+
+	const record = component as Record<string, unknown>
+	const children = Array.isArray(record.components)
+		? record.components.flatMap(flattenComponents)
+		: []
+
+	return [record, ...children]
+}
+
+const replyText = (replies: unknown[]) =>
+	replies
+		.flatMap((reply) => flattenComponents(serializePayload(reply)))
+		.map((component) => component.content)
+		.filter((content): content is string => typeof content === "string")
+		.join("\n")
+
+const runAccept = async () => {
+	const replies: unknown[] = []
+	const dms: unknown[] = []
+	const announcements: unknown[] = []
+	const patches: unknown[] = []
+	const acceptButton = claimReviewComponents[0]
+	const interaction = {
+		user: { id: "reviewer-1" },
+		message: {
+			id: "review-message-1",
+			channelId: "review-channel-1",
+			rawData: { components: [] }
+		},
+		reply: async (payload: unknown) => {
+			replies.push(payload)
+		},
+		client: {
+			fetchUser: async () => ({
+				send: async (payload: unknown) => {
+					dms.push(payload)
+				}
+			}),
+			fetchChannel: async () => ({
+				send: async (payload: unknown) => {
+					announcements.push(payload)
+				}
+			}),
+			rest: {
+				patch: async (...args: unknown[]) => {
+					patches.push(args)
+				}
+			}
+		}
+	} as unknown as ButtonInteraction
+
+	await acceptButton.run(interaction, {
+		userId: "suser-1",
+		guildId: "sguild-1"
+	})
+
+	return { replies, dms, announcements, patches, text: replyText(replies) }
+}
+
+describe("claim review accept persist", () => {
+	it("does not report accepted when decision persist fails", async () => {
+		setRuntimeEnv({ DISCORD_BOT_TOKEN: "test-token" } as Env)
+		const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+			async () => new Response(null, { status: 204 })
+		)
+		const persistSpy = spyOn(
+			claimRequests,
+			"recordClaimDecision"
+		).mockImplementation(async () => {
+			throw new Error("database unavailable")
+		})
+		const consoleError = spyOn(console, "error").mockImplementation(() => {})
+
+		try {
+			const result = await runAccept()
+
+			expect(persistSpy).toHaveBeenCalledTimes(1)
+			expect(result.replies).toHaveLength(1)
+			expect(result.text.toLowerCase()).not.toContain("claim accepted")
+			expect(result.text.toLowerCase()).not.toContain("has been given the role")
+			expect(result.dms).toHaveLength(0)
+			expect(result.announcements).toHaveLength(0)
+			expect(result.patches).toHaveLength(0)
+			expect(result.text).toContain("Could not record claim")
+		} finally {
+			consoleError.mockRestore()
+			persistSpy.mockRestore()
+			fetchSpy.mockRestore()
+		}
+	})
+
+	it("reports accepted after the decision is recorded", async () => {
+		setRuntimeEnv({ DISCORD_BOT_TOKEN: "test-token" } as Env)
+		const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+			async () => new Response(null, { status: 204 })
+		)
+		const persistSpy = spyOn(
+			claimRequests,
+			"recordClaimDecision"
+		).mockImplementation(async () => {})
+		const consoleError = spyOn(console, "error").mockImplementation(() => {})
+
+		try {
+			const result = await runAccept()
+
+			expect(persistSpy).toHaveBeenCalledTimes(1)
+			expect(result.text.toLowerCase()).toContain("claim accepted")
+			expect(result.dms).toHaveLength(1)
+			expect(result.announcements).toHaveLength(1)
+		} finally {
+			consoleError.mockRestore()
+			persistSpy.mockRestore()
+			fetchSpy.mockRestore()
+		}
+	})
+})


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a reviewer pressing Accept on a clawtributor claim would be told the claim was accepted even when saving the decision to the database failed. Discord could add the clawtributors role, then the bot still DMed the claimant, posted the announcement, and replied "Claim accepted" while the stored claim stayed pending.

That false success is worse than a failed Accept: staff think the review is finished, the claimant is told they are a clawtributor, and a later `/claim` still looks pending.

## Why This Change Was Made

Accept now waits for `recordClaimDecision` to finish. If the write fails, the review button replies with an error and does not DM, announce, or mark the review message accepted. The previous success copy is sent only after the decision is saved. Reject is unchanged.

## User Impact

Reviewers get an accurate private reply when Accept cannot save the decision. A database failure no longer looks like a completed clawtributor grant. Claimants are not told they were accepted while the claim record is still pending.

## Evidence

Live `bun` run of `/tmp/proof-hermit-F004.ts` against upstream `src/server/claimServer.ts` and this branch. The script calls the production Accept button (`claimReviewComponents[0].run`) after Discord's role PUT returns 204. One run makes `recordClaimDecision` throw `database unavailable`. The other run lets the write finish.

```console
$ bash /tmp/proof-hermit-F004.sh
===== BEFORE (upstream accept swallows persist errors) =====
PERSIST REJECT
{
  "reply": "Claim accepted. <@user-1> has been given the role.",
  "dmCount": 1,
  "announcementCount": 1,
  "patchCount": 1
}
PERSIST OK
{
  "reply": "Claim accepted. <@user-1> has been given the role.",
  "dmCount": 1,
  "announcementCount": 1,
  "patchCount": 1
}
===== AFTER (patched accept surfaces persist errors) =====
PERSIST REJECT
{
  "reply": "Could not record claim. The clawtributors role was added, but the claim decision could not be saved. Ask a moderator to retry or update the claim record.",
  "dmCount": 0,
  "announcementCount": 0,
  "patchCount": 0
}
PERSIST OK
{
  "reply": "Claim accepted. <@user-1> has been given the role.",
  "dmCount": 1,
  "announcementCount": 1,
  "patchCount": 1
}
```

Before this patch a failed decision write still printed Claim accepted, sent the DM, announced the grant, and patched the review message. After the patch a failed write prints Could not record claim and skips those success side effects. A successful write still prints Claim accepted.

Related: the swallow landed in [#10](https://github.com/openclaw/hermit/pull/10) ([`2b970350`](https://github.com/openclaw/hermit/commit/2b970350), 2026-05-12). Same false-success class as [#26](https://github.com/openclaw/hermit/pull/26) (automod-bypass role changes) and [#27](https://github.com/openclaw/hermit/pull/27) (inactivity-warn addMember).

## Real behavior proof

- **Behavior or issue addressed:** Review-channel Accept reported Claim accepted, DMed the claimant, and announced the clawtributors grant even when saving the accepted decision failed, so the stored claim stayed pending.
- **Real environment tested:** macOS 26.6.1 Darwin 25.6.0 arm64, Node v26.7.0, bun 1.3.14, patched checkout `/tmp/oc-pr-hermit-F004` on `fix/f004-claim-persist-error` (base [`72b5de1`](https://github.com/openclaw/hermit/commit/72b5de1)).
- **Exact steps or command run after this patch:**

  ```bash
  bash /tmp/proof-hermit-F004.sh
  ```

- **Evidence after fix:** terminal output from the patched Accept handler:

  ```console
  $ bash /tmp/proof-hermit-F004.sh
  AFTER persist reject
  {
    "reply": "Could not record claim. The clawtributors role was added, but the claim decision could not be saved. Ask a moderator to retry or update the claim record.",
    "dmCount": 0,
    "announcementCount": 0,
    "patchCount": 0
  }
  AFTER persist ok
  {
    "reply": "Claim accepted. <@user-1> has been given the role.",
    "dmCount": 1,
    "announcementCount": 1,
    "patchCount": 1
  }
  ```

- **Observed result after fix:** A failed decision write now replies Could not record claim and does not DM, announce, or patch the review message. A successful write still replies Claim accepted and still DMs, announces, and patches.
- **What was not tested:** A live Discord review-channel click against production D1. Discord role PUT was stubbed to 204 so the persist path is the only failure.

## Summary

Accept no longer treats a swallowed `recordClaimDecision` error as a completed grant. Persist is awaited on the success path. Persist failure replies with an error.
