### PR TITLE
fix(forms): do not accept or deny when form actions fail

### DIFF
--- a/src/forms/reviewButtons.ts
+++ b/src/forms/reviewButtons.ts
@@ -323,7 +323,13 @@ const decide = async (
 			actionResult = `${actionResult}\nNew duration: ${duration}`
 		}
 	} catch (error) {
-		actionResult = error instanceof Error ? error.message : "Unknown action error."
+		const message = error instanceof Error ? error.message : "Unknown action error."
+		await interaction.reply({
+			components: [resultContainer("Form action failed", message, "#f85149")],
+			ephemeral: true,
+			allowedMentions: { parse: [] }
+		})
+		return
 	}
 
 	await recordFormDecision(loaded.id, {

--- a/tests/formReviewActionFailure.test.ts
+++ b/tests/formReviewActionFailure.test.ts
@@ -1,0 +1,190 @@
+import { type ModalInteraction, serializePayload } from "@buape/carbon"
+import { describe, expect, it, spyOn } from "bun:test"
+import { formConfigs, formSettings } from "../forms.config.js"
+import * as formActions from "../src/forms/actions.js"
+import { formReviewModals } from "../src/forms/reviewButtons.js"
+import * as formSubmissions from "../src/forms/submissions.js"
+
+const flattenComponents = (component: unknown): Record<string, unknown>[] => {
+	if (!component || typeof component !== "object") {
+		return []
+	}
+
+	const record = component as Record<string, unknown>
+	const children = Array.isArray(record.components)
+		? record.components.flatMap(flattenComponents)
+		: []
+
+	return [record, ...children]
+}
+
+const payloadText = (payloads: unknown[]) =>
+	payloads
+		.flatMap((payload) => flattenComponents(serializePayload(payload)))
+		.map((component) => component.content)
+		.filter((content): content is string => typeof content === "string")
+		.join("\n")
+
+const pendingSubmission = {
+	id: 42,
+	formId: "discord-ban",
+	status: "submitted",
+	authProvider: "discord",
+	applicantId: "applicant-1",
+	applicantUsername: "Applicant",
+	payload: JSON.stringify({
+		action: "banned",
+		punishment: "Ban",
+		appealReason: "Please unban me"
+	}),
+	reviewChannelId: formSettings.reviewChannelId,
+	reviewMessageId: "review-message-1",
+	reviewThreadId: null,
+	decidedAt: null,
+	decidedById: null,
+	decisionReason: null,
+	actionResult: null,
+	createdAt: "2026-09-01T00:00:00.000Z",
+	updatedAt: "2026-09-01T00:00:00.000Z"
+}
+
+const runDecision = async (status: "accepted" | "denied") => {
+	const replies: unknown[] = []
+	const updates: unknown[] = []
+	const dms: unknown[] = []
+	const interaction = {
+		user: { id: "reviewer-1" },
+		member: { roles: [{ id: formSettings.reviewRoleId }] },
+		fields: {
+			getText: () => undefined
+		},
+		reply: async (payload: unknown) => {
+			replies.push(payload)
+		},
+		update: async (payload: unknown) => {
+			updates.push(payload)
+		},
+		client: {
+			fetchUser: async () => ({
+				send: async (payload: unknown) => {
+					dms.push(payload)
+				}
+			})
+		}
+	} as unknown as ModalInteraction
+
+	await formReviewModals[0].run(interaction, {
+		id: pendingSubmission.id,
+		status
+	})
+
+	return {
+		replies,
+		updates,
+		dms,
+		replyText: payloadText(replies),
+		updateText: payloadText(updates)
+	}
+}
+
+describe("form review action failure", () => {
+	it("does not record accepted when form actions throw", async () => {
+		process.env.DISCORD_CLIENT_ID = "test-client"
+		process.env.DISCORD_CLIENT_SECRET = "test-secret"
+
+		const form = formConfigs.find((item) => item.id === "discord-ban")
+		expect(form).toBeDefined()
+
+		const loadSpy = spyOn(formSubmissions, "getFormSubmission").mockImplementation(
+			async () => pendingSubmission
+		)
+		const persistSpy = spyOn(formSubmissions, "recordFormDecision").mockImplementation(
+			async () => {}
+		)
+		const actionSpy = spyOn(formActions, "runFormActions").mockImplementation(async () => {
+			throw new Error("Discord 403: Missing Permissions")
+		})
+
+		try {
+			const result = await runDecision("accepted")
+
+			expect(actionSpy).toHaveBeenCalledTimes(1)
+			expect(persistSpy).not.toHaveBeenCalled()
+			expect(result.updates).toHaveLength(0)
+			expect(result.dms).toHaveLength(0)
+			expect(result.replies).toHaveLength(1)
+			expect(result.replyText).toContain("Discord 403: Missing Permissions")
+			expect(result.replyText.toLowerCase()).not.toContain("accepted")
+			expect(result.updateText.toLowerCase()).not.toContain("accepted")
+		} finally {
+			loadSpy.mockRestore()
+			persistSpy.mockRestore()
+			actionSpy.mockRestore()
+		}
+	})
+
+	it("does not record denied when form actions throw", async () => {
+		process.env.DISCORD_CLIENT_ID = "test-client"
+		process.env.DISCORD_CLIENT_SECRET = "test-secret"
+
+		const loadSpy = spyOn(formSubmissions, "getFormSubmission").mockImplementation(
+			async () => pendingSubmission
+		)
+		const persistSpy = spyOn(formSubmissions, "recordFormDecision").mockImplementation(
+			async () => {}
+		)
+		const actionSpy = spyOn(formActions, "runFormActions").mockImplementation(async () => {
+			throw new Error("Discord 403: Missing Permissions")
+		})
+
+		try {
+			const result = await runDecision("denied")
+
+			expect(actionSpy).toHaveBeenCalledTimes(1)
+			expect(persistSpy).not.toHaveBeenCalled()
+			expect(result.updates).toHaveLength(0)
+			expect(result.dms).toHaveLength(0)
+			expect(result.replies).toHaveLength(1)
+			expect(result.replyText).toContain("Discord 403: Missing Permissions")
+		} finally {
+			loadSpy.mockRestore()
+			persistSpy.mockRestore()
+			actionSpy.mockRestore()
+		}
+	})
+
+	it("records accepted after form actions succeed", async () => {
+		process.env.DISCORD_CLIENT_ID = "test-client"
+		process.env.DISCORD_CLIENT_SECRET = "test-secret"
+
+		const loadSpy = spyOn(formSubmissions, "getFormSubmission").mockImplementation(
+			async () => pendingSubmission
+		)
+		const persistSpy = spyOn(formSubmissions, "recordFormDecision").mockImplementation(
+			async () => {}
+		)
+		const actionSpy = spyOn(formActions, "runFormActions").mockImplementation(
+			async () => "discord.unban"
+		)
+
+		try {
+			const result = await runDecision("accepted")
+
+			expect(actionSpy).toHaveBeenCalledTimes(1)
+			expect(persistSpy).toHaveBeenCalledTimes(1)
+			expect(persistSpy.mock.calls[0]?.[0]).toBe(pendingSubmission.id)
+			expect(persistSpy.mock.calls[0]?.[1]).toMatchObject({
+				status: "accepted",
+				decidedById: "reviewer-1",
+				actionResult: "discord.unban"
+			})
+			expect(result.updates).toHaveLength(1)
+			expect(result.dms).toHaveLength(1)
+			expect(result.updateText.toLowerCase()).toContain("accepted")
+		} finally {
+			loadSpy.mockRestore()
+			persistSpy.mockRestore()
+			actionSpy.mockRestore()
+		}
+	})
+})


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a reviewer pressing Accept (or Deny) on a Discord form appeal would close the submission as accepted or denied even when the configured follow-up failed. A Discord unban or role grant that returned 403 still stored `accepted`, DMed the applicant that the appeal was accepted, and replaced the review message with a decided card.

That false success is worse than a failed click: staff think the appeal is finished, the applicant is told they were unbanned, and the row can no longer be retried because it is already terminal.

## Why This Change Was Made

`decide()` now returns after `runFormActions` throws. The modal replies with the action error and leaves the submission pending. `recordFormDecision`, the applicant DM, and the decided review-card update run only after the action completes. Empty deny lists still succeed as before; only a thrown action blocks the terminal write.

## User Impact

Reviewers see the Discord or GitHub action error on the Accept/Deny modal and can retry while the appeal is still pending. Applicants are not told they were accepted or denied when the unban, role grant, or unblock did not run.

## Evidence

Live `bun` run of `/tmp/proof-hermit-F006.ts` against upstream `src/forms/reviewButtons.ts` and this branch. The script calls the production review modal (`formReviewModals[0].run`) for a pending `discord-ban` submission. `runFormActions` throws `Discord 403: Missing Permissions`, which is the same error `discordRequest` raises on a failed unban.

```console
$ bash /tmp/proof-hermit-F006.sh
===== BEFORE (upstream decide records accepted after action throw) =====
{
  "persistCalls": [
    {
      "id": 42,
      "status": "accepted",
      "decidedById": "reviewer-1",
      "decisionReason": null,
      "actionResult": "Discord 403: Missing Permissions"
    }
  ],
  "reply": null,
  "updateCount": 1,
  "dmCount": 1
}
===== AFTER (patched decide leaves submission pending) =====
{
  "persistCalls": [],
  "reply": "Form action failed / Discord 403: Missing Permissions",
  "update": null,
  "dmCount": 0,
  "updateCount": 0
}
```

Before this patch a thrown unban still persisted `status: accepted`, DMed the applicant, and updated the review card as Accepted. After the patch persistCalls is empty, there is no DM, the review card is not updated, and the modal replies Form action failed with the Discord 403 text.

Related: the catch-and-close path landed in [`d4e8cdb4`](https://github.com/openclaw/hermit/commit/d4e8cdb499f652f130e00cc7d8bdbd34eb1e250c) (2026-05-23, OpenClaw forms). Same false-success class as [#26](https://github.com/openclaw/hermit/pull/26) (automod-bypass role changes), [#27](https://github.com/openclaw/hermit/pull/27) (inactivity-warn addMember), and [#33](https://github.com/openclaw/hermit/pull/33) (claim accept persist).

## Real behavior proof

- **Behavior or issue addressed:** Form review Accept recorded the appeal as accepted, DMed the applicant, and replaced the review card after a thrown Discord unban, so a failed unban still closed the appeal.
- **Real environment tested:** macOS 26.6.1 Darwin 25.6.0 arm64, Node v26.7.0, bun 1.3.14, patched checkout `/tmp/hermit-f006` on `fix/form-review-action-failure` (base [`f0d9924`](https://github.com/openclaw/hermit/commit/f0d9924637baa4ae139faf20ffb272edd6970305)).
- **Exact steps or command run after this patch:**

  ```bash
  bash /tmp/proof-hermit-F006.sh
  ```

- **Evidence after fix:** terminal output from the patched decide path:

  ```console
  $ bash /tmp/proof-hermit-F006.sh
  AFTER persist
  {
    "persistCalls": [],
    "reply": "Form action failed / Discord 403: Missing Permissions",
    "update": null,
    "dmCount": 0,
    "updateCount": 0
  }
  ```

- **Observed result after fix:** A thrown Discord unban now replies Form action failed and does not persist accepted, DM the applicant, or update the review card. persistCalls stays empty so the submission remains pending.
- **What was not tested:** A live Discord review-channel click against production D1 and a real guild unban. Discord REST was stubbed to throw 403 so the persist path is the only side effect under test.

## Summary

Accept and Deny no longer treat a failed form action as a completed decision. The submission stays pending until the action succeeds.
