### PR TITLE
fix(logs): require deploy secret on helper events API

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ bun run db:apply:remote
 bun run dev
 ```
 
+## Helper logs API
+
+`GET /api/events` and `GET /api/threads` require `Authorization: Bearer <DEPLOY_SECRET>`. Update any scripts consuming these endpoints to send that header. Missing or incorrect credentials return HTTP 401; the endpoints also reject requests when `DEPLOY_SECRET` is unset.
+
+The HTML index at `/` remains public and contains only endpoint links and filter documentation.
+
 ## Scripts
 
 - `bun run dev` → `wrangler dev --env-file .env`

--- a/src/server/helperLogsServer.ts
+++ b/src/server/helperLogsServer.ts
@@ -1,5 +1,6 @@
 import type { Client } from "@buape/carbon"
 import { listEvents, listTrackedThreads } from "../data/helperLogs.js"
+import { getRuntimeEnv } from "../runtime/env.js"
 
 const asStringOrNull = (value: unknown): string | null =>
 	typeof value === "string" && value.trim().length > 0 ? value.trim() : null
@@ -21,6 +22,18 @@ const json = (data: unknown, init?: ResponseInit) =>
 			...init?.headers
 		}
 	})
+
+const bearerToken = (request: Request) =>
+	request.headers.get("authorization")?.match(/^Bearer\s+(.+)$/i)?.[1] ?? ""
+
+const requireDeploySecret = (request: Request) => {
+	const token = getRuntimeEnv().DEPLOY_SECRET
+	if (!token || bearerToken(request) !== token) {
+		return json({ error: "Unauthorized" }, { status: 401 })
+	}
+
+	return null
+}
 
 const renderHtml = () => `<!doctype html>
 <html lang="en">
@@ -62,6 +75,11 @@ export const registerHelperLogsRoutes = (client: Client) => {
 			method: "GET",
 			path: "/api/events",
 			handler: async (request) => {
+				const denied = requireDeploySecret(request)
+				if (denied) {
+					return denied
+				}
+
 				const url = new URL(request.url)
 				const events = await listEvents({
 					eventType: asStringOrNull(url.searchParams.get("eventType")),
@@ -80,6 +98,11 @@ export const registerHelperLogsRoutes = (client: Client) => {
 			method: "GET",
 			path: "/api/threads",
 			handler: async (request) => {
+				const denied = requireDeploySecret(request)
+				if (denied) {
+					return denied
+				}
+
 				const url = new URL(request.url)
 				const threads = await listTrackedThreads({
 					threadId: asStringOrNull(url.searchParams.get("threadId")),

--- a/tests/helperLogsApi.test.ts
+++ b/tests/helperLogsApi.test.ts
@@ -1,0 +1,169 @@
+import { Database } from "bun:sqlite"
+import { describe, expect, it } from "bun:test"
+import { readFileSync } from "node:fs"
+import type { Client } from "@buape/carbon"
+import { registerHelperLogsRoutes } from "../src/server/helperLogsServer.js"
+import { setRuntimeEnv } from "../src/runtime/env.js"
+import { SqliteD1Database } from "./helpers/sqliteD1.js"
+
+const applyMigration = (database: Database, path: string) => {
+	const migration = readFileSync(path, "utf8")
+	for (const statement of migration.split("--> statement-breakpoint")) {
+		const trimmed = statement.trim()
+		if (trimmed.length > 0) {
+			database.run(trimmed)
+		}
+	}
+}
+
+const seedHelperLogs = (owner: SqliteD1Database) => {
+	owner.database.run(
+		"insert into helper_events (event_type, thread_id, message_count, event_time, command, invoked_by_id, invoked_by_username, invoked_by_global_name, raw_payload) values (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		[
+			"helper_command",
+			"111",
+			2,
+			"2026-09-02T00:00:00.000Z",
+			"/helper close-thread",
+			"222",
+			"helper-user",
+			"Helper User",
+			"{}"
+		]
+	)
+	owner.database.run(
+		"insert into tracked_threads (thread_id, created_at, last_checked, solved, warning_level, closed, last_message_count, raw_payload) values (?, ?, ?, ?, ?, ?, ?, ?)",
+		[
+			"111",
+			"2026-09-02T00:00:00.000Z",
+			"2026-09-02T00:01:00.000Z",
+			0,
+			0,
+			0,
+			2,
+			"{}"
+		]
+	)
+}
+
+const routesFor = (secret = "deploy-secret") => {
+	const owner = new SqliteD1Database()
+	applyMigration(owner.database, "drizzle/0000_productive_tinkerer.sql")
+	seedHelperLogs(owner)
+	setRuntimeEnv({
+		DB: owner as unknown as D1Database,
+		DEPLOY_SECRET: secret
+	} as Env)
+
+	const client = { routes: [] as Array<{
+		method: string
+		path: string
+		handler: (request: Request) => Response | Promise<Response>
+	}> }
+	registerHelperLogsRoutes(client as unknown as Client)
+	return client
+}
+
+const route = (
+	client: ReturnType<typeof routesFor>,
+	path: string
+) => {
+	const found = client.routes.find((entry) => entry.method === "GET" && entry.path === path)
+	if (!found) {
+		throw new Error(`Missing GET ${path}`)
+	}
+	return found
+}
+
+describe("helper logs HTTP API", () => {
+	it("rejects unauthenticated GET /api/events", async () => {
+		const client = routesFor()
+		const response = await route(client, "/api/events").handler(
+			new Request("https://hermit-discord.openclaw.ai/api/events")
+		)
+
+		expect(response.status).toBe(401)
+		expect(await response.json()).toEqual({ error: "Unauthorized" })
+	})
+
+	it("rejects unauthenticated GET /api/threads", async () => {
+		const client = routesFor()
+		const response = await route(client, "/api/threads").handler(
+			new Request("https://hermit-discord.openclaw.ai/api/threads")
+		)
+
+		expect(response.status).toBe(401)
+		expect(await response.json()).toEqual({ error: "Unauthorized" })
+	})
+
+	it("rejects authorization headers without the Bearer scheme", async () => {
+		const client = routesFor()
+		const response = await route(client, "/api/events").handler(
+			new Request("https://hermit-discord.openclaw.ai/api/events", {
+				headers: { Authorization: "deploy-secret" }
+			})
+		)
+
+		expect(response.status).toBe(401)
+	})
+
+	it("rejects the wrong bearer token", async () => {
+		const client = routesFor()
+		const response = await route(client, "/api/threads").handler(
+			new Request("https://hermit-discord.openclaw.ai/api/threads", {
+				headers: { Authorization: "Bearer wrong-secret" }
+			})
+		)
+
+		expect(response.status).toBe(401)
+	})
+
+	it("returns helper events when the deploy secret is presented", async () => {
+		const client = routesFor()
+		const response = await route(client, "/api/events").handler(
+			new Request("https://hermit-discord.openclaw.ai/api/events?limit=10", {
+				headers: { Authorization: "Bearer deploy-secret" }
+			})
+		)
+		const body = await response.json() as { count: number; events: Array<{ command: string }> }
+
+		expect(response.status).toBe(200)
+		expect(body.count).toBe(1)
+		expect(body.events[0]?.command).toBe("/helper close-thread")
+	})
+
+	it("returns tracked threads when the deploy secret is presented", async () => {
+		const client = routesFor()
+		const response = await route(client, "/api/threads").handler(
+			new Request("https://hermit-discord.openclaw.ai/api/threads?limit=10", {
+				headers: { Authorization: "Bearer deploy-secret" }
+			})
+		)
+		const body = await response.json() as { count: number; threads: Array<{ thread_id: string }> }
+
+		expect(response.status).toBe(200)
+		expect(body.count).toBe(1)
+		expect(body.threads[0]?.thread_id).toBe("111")
+	})
+
+	it("keeps the HTML index public", async () => {
+		const client = routesFor()
+		const response = await route(client, "/").handler(
+			new Request("https://hermit-discord.openclaw.ai/")
+		)
+
+		expect(response.status).toBe(200)
+		expect(response.headers.get("content-type")).toContain("text/html")
+	})
+
+	it("rejects JSON reads when DEPLOY_SECRET is unset", async () => {
+		const client = routesFor("")
+		const response = await route(client, "/api/events").handler(
+			new Request("https://hermit-discord.openclaw.ai/api/events", {
+				headers: { Authorization: "Bearer deploy-secret" }
+			})
+		)
+
+		expect(response.status).toBe(401)
+	})
+})


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where anyone on the public internet could list Hermit helper activity and tracked support threads by opening two HTTP URLs. `GET https://hermit-discord.openclaw.ai/api/events` and `GET https://hermit-discord.openclaw.ai/api/threads` returned JSON with Discord user ids, usernames, helper command names, thread ids, and thread state (solved, closed, message counts), up to 500 rows, with no `Authorization` header.

This is public information disclosure of Discord operational metadata. It is not a credential or token leak. `command` values are hardcoded helper commands such as `/helper close-thread`. Sibling worker APIs (ClawHub publisher-abuse digest and content-rights staff API) already require a bearer token. These two helper-log endpoints did not.

## Why This Change Was Made

The JSON handlers now require `Authorization: Bearer <DEPLOY_SECRET>`, the same Bearer scheme used by the publisher-abuse and content-rights APIs, using the existing worker deploy secret. Missing, wrong, or non-Bearer credentials return `401 {"error":"Unauthorized"}`. An empty `DEPLOY_SECRET` also returns 401 (fail closed). The HTML index at `/` stays public and does not include event rows.

## User Impact

Anonymous clients can no longer read helper event history or tracked thread lists from the public worker. Operators who already hold `DEPLOY_SECRET` can keep using the JSON APIs with a Bearer header. Discord helper commands themselves are unchanged.

## Evidence

Live unauthenticated read of production on 2026-09-02 (user ids, usernames, and thread ids redacted):

```console
$ curl -sS -D - -o /tmp/hermit-events-body.json -w 'HTTP %{http_code}\n' \
    'https://hermit-discord.openclaw.ai/api/events?limit=2'
HTTP/2 200
content-type: application/json; charset=utf-8

{
  "count": 2,
  "events": [
    {
      "event_type": "helper_command",
      "thread_id": "<redacted>",
      "message_count": 1329,
      "command": "/helper close-thread",
      "invoked_by_id": "<redacted>",
      "invoked_by_username": "<redacted>"
    }
  ]
}

$ curl -sS -o /tmp/hermit-threads-body.json -w 'HTTP %{http_code}\n' \
    'https://hermit-discord.openclaw.ai/api/threads?limit=2'
HTTP 200
```

After the patch, the same route handlers on a local Worker-shaped D1 (synthetic rows only) refuse anonymous and wrong-secret reads, then return the seeded rows with the deploy secret:

```console
$ bun /tmp/hermit-f005-proof.mjs
UNAUTH events
HTTP 401
{"error":"Unauthorized"}

UNAUTH threads
HTTP 401
{"error":"Unauthorized"}

WRONG events
HTTP 401
{"error":"Unauthorized"}

AUTH events
HTTP 200
{"count":1,"events":[{"id":1,"event_type":"helper_command","thread_id":"111","command":"/helper close-thread","invoked_by_id":"222","invoked_by_username":"helper-user"}]}

AUTH threads
HTTP 200
{"count":1,"threads":[{"id":1,"thread_id":"111","solved":0,"closed":0}]}
```

Same-repo siblings that already use this Bearer gate: [#17](https://github.com/openclaw/hermit/pull/17) (publisher-abuse digest) and [#15](https://github.com/openclaw/hermit/pull/15) (content-rights staff API). No open PR already locks `/api/events` or `/api/threads`.

## Real behavior proof

- **Behavior or issue addressed:** Public `GET /api/events` and `GET /api/threads` listed helper events and tracked threads without a secret. After this patch they return 401 unless `Authorization: Bearer <DEPLOY_SECRET>` is present and matches.
- **Real environment tested:** macOS, bun 1.3.14, patched `src/server/helperLogsServer.ts` in `/tmp/hermit-f005` at branch `fix/helper-logs-auth`. Production before-fix capture against `https://hermit-discord.openclaw.ai` (custom domain from `wrangler.jsonc`).
- **Exact steps or command run after this patch:**

  ```bash
  curl -sS -o /tmp/hermit-events-body.json -w 'HTTP %{http_code}\n' \
    'https://hermit-discord.openclaw.ai/api/events?limit=2'
  bun /tmp/hermit-f005-proof.mjs
  ```

- **Evidence after fix:** terminal output from the patched handlers (see Evidence). Unauthenticated and wrong-secret requests print `HTTP 401` and `{"error":"Unauthorized"}`. The matching Bearer secret prints `HTTP 200` with the seeded event (`/helper close-thread`) and thread (`111`).
- **Observed result after fix:** Anonymous and wrong-secret callers no longer receive event or thread JSON. A valid deploy secret still returns the list payload.
- **What was not tested:** Cloudflare production deploy of this branch (the public worker still serves the old unauthenticated handlers until this lands). Timing-safe compare is not added; the check matches the existing sibling `!==` Bearer compare.

## Related

- Same-repo bearer gates: [#17](https://github.com/openclaw/hermit/pull/17), [#15](https://github.com/openclaw/hermit/pull/15)
- Routes registered from [`src/index.ts`](https://github.com/openclaw/hermit/blob/main/src/index.ts) via `registerHelperLogsRoutes`
- Public custom domain: `hermit-discord.openclaw.ai` in `wrangler.jsonc`
