### PR TITLE
fix(claim): do not report reject when decision persist fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ bun run db:generate
 bun run db:apply:remote
 ```
 
+## Clawtributor claim review
+
+If saving a rejection fails, Hermit does not notify the applicant and restores the review buttons for another attempt. If Discord also rejects the message update, the reviewer receives an error explaining that the review could not be reopened automatically and needs moderator recovery.
+
 ## Gateway forwarder
 
 The main bot runs as a Cloudflare Worker. Gateway events are forwarded by the Bun app in `forwarder/`, usually running on Krill's machine.

--- a/src/server/claimServer.ts
+++ b/src/server/claimServer.ts
@@ -471,15 +471,32 @@ class ClaimReviewRejectModal extends Modal {
 			return
 		}
 
-		await recordClaimDecision({
-			userId,
-			guildId,
-			status: "rejected",
-			decidedById: interaction.user?.id,
-			decisionReason: reason
-		}).catch((error) => {
+		try {
+			await recordClaimDecision({
+				userId,
+				guildId,
+				status: "rejected",
+				decidedById: interaction.user?.id,
+				decisionReason: reason
+			})
+		} catch (error) {
 			console.error("Failed to record rejected claim:", error)
-		})
+			await interaction.reply({
+				components: [
+					new Container(
+						[
+							new TextDisplay("### Could not record claim"),
+							new TextDisplay(
+								"The claim decision could not be saved. The applicant was not notified. Ask a moderator to retry or update the claim record."
+							)
+						],
+						{ accentColor: "#f85149" }
+					)
+				],
+				ephemeral: true
+			})
+			return
+		}
 
 		const user = await interaction.client.fetchUser(userId).catch(() => null)
 		await user?.send({

--- a/src/server/claimServer.ts
+++ b/src/server/claimServer.ts
@@ -433,6 +433,74 @@ class ClaimReviewReasonLabel extends Label {
 	}
 }
 
+const restorePendingClaimReview = async (
+	interaction: ModalInteraction,
+	userId: string,
+	guildId: string
+) => {
+	const message = interaction.message
+	const components = message?.rawData.components
+	if (!message || components?.length !== 1) return false
+	const container = components[0]
+	if (container.type !== ComponentType.Container) return false
+
+	const children = container.components
+	const footer = children.at(-1)
+	const separator = children.at(-2)
+	const row = children.at(-3)
+	if (
+		footer?.type !== ComponentType.TextDisplay ||
+		footer.content !==
+			`Rejection in progress by <@${interaction.user?.id ?? "unknown"}>.` ||
+		separator?.type !== ComponentType.Separator ||
+		row?.type !== ComponentType.ActionRow ||
+		row.components.length !== 2 ||
+		!["accept", "reject"].every((action) =>
+			row.components.some(
+				(button) =>
+					"custom_id" in button &&
+					button.custom_id ===
+						`claim-review-${action}:userId=s${userId};guildId=s${guildId}`
+			)
+		)
+	) {
+		return false
+	}
+
+	const restored: Container["components"] = []
+	for (const child of children.slice(0, -3)) {
+		if (child.type === ComponentType.TextDisplay) {
+			restored.push(new TextDisplay(child.content))
+		} else if (child.type === ComponentType.Separator) {
+			restored.push(
+				new Separator({
+					divider: child.divider,
+					spacing: child.spacing === 2 ? "large" : "small"
+				})
+			)
+		} else {
+			// Preserve unfamiliar cards rather than silently dropping their content.
+			return false
+		}
+	}
+	restored.push(
+		new Row([
+			new ClaimReviewAcceptButton(userId, guildId),
+			new ClaimReviewRejectButton(userId, guildId)
+		])
+	)
+	await message.edit({
+		components: [
+			new Container(restored, {
+				accentColor: container.accent_color ?? undefined,
+				spoiler: container.spoiler
+			})
+		],
+		allowedMentions: { parse: [] }
+	})
+	return true
+}
+
 class ClaimReviewRejectModal extends Modal {
 	title = "Reject Clawtributor Claim"
 	customId = "claim-review-reject-modal"
@@ -481,13 +549,23 @@ class ClaimReviewRejectModal extends Modal {
 			})
 		} catch (error) {
 			console.error("Failed to record rejected claim:", error)
+			const restored = await restorePendingClaimReview(
+				interaction,
+				userId,
+				guildId
+			).catch((restoreError) => {
+				console.error("Failed to restore claim review message:", restoreError)
+				return false
+			})
 			await interaction.reply({
 				components: [
 					new Container(
 						[
 							new TextDisplay("### Could not record claim"),
 							new TextDisplay(
-								"The claim decision could not be saved. The applicant was not notified. Ask a moderator to retry or update the claim record."
+								restored
+									? "The claim decision could not be saved. The applicant was not notified. The review buttons have been restored; please try again."
+									: "The claim decision could not be saved. The applicant was not notified, and the review could not be reopened automatically. Ask a moderator to restore the review message or update the claim record."
 							)
 						],
 						{ accentColor: "#f85149" }

--- a/tests/claimRejectPersist.test.ts
+++ b/tests/claimRejectPersist.test.ts
@@ -1,0 +1,111 @@
+import { type ModalInteraction, serializePayload } from "@buape/carbon"
+import { describe, expect, it, spyOn } from "bun:test"
+import * as claimRequests from "../src/data/claimRequests.js"
+import { claimReviewModals } from "../src/server/claimServer.js"
+
+const flattenComponents = (component: unknown): Record<string, unknown>[] => {
+	if (!component || typeof component !== "object") {
+		return []
+	}
+
+	const record = component as Record<string, unknown>
+	const children = Array.isArray(record.components)
+		? record.components.flatMap(flattenComponents)
+		: []
+
+	return [record, ...children]
+}
+
+const replyText = (replies: unknown[]) =>
+	replies
+		.flatMap((reply) => flattenComponents(serializePayload(reply)))
+		.map((component) => component.content)
+		.filter((content): content is string => typeof content === "string")
+		.join("\n")
+
+const runReject = async () => {
+	const replies: unknown[] = []
+	const dms: unknown[] = []
+	const patches: unknown[] = []
+	const rejectModal = claimReviewModals[0]
+	const interaction = {
+		user: { id: "reviewer-1" },
+		fields: {
+			getText: () => "too few merged PRs"
+		},
+		message: {
+			id: "review-message-1",
+			channelId: "review-channel-1",
+			rawData: { components: [] }
+		},
+		reply: async (payload: unknown) => {
+			replies.push(payload)
+		},
+		client: {
+			fetchUser: async () => ({
+				send: async (payload: unknown) => {
+					dms.push(payload)
+				}
+			}),
+			rest: {
+				patch: async (...args: unknown[]) => {
+					patches.push(args)
+				}
+			}
+		}
+	} as unknown as ModalInteraction
+
+	await rejectModal.run(interaction, {
+		userId: "suser-1",
+		guildId: "sguild-1"
+	})
+
+	return { replies, dms, patches, text: replyText(replies) }
+}
+
+describe("claim review reject persist", () => {
+	it("does not report rejected when decision persist fails", async () => {
+		const persistSpy = spyOn(
+			claimRequests,
+			"recordClaimDecision"
+		).mockImplementation(async () => {
+			throw new Error("database unavailable")
+		})
+		const consoleError = spyOn(console, "error").mockImplementation(() => {})
+
+		try {
+			const result = await runReject()
+
+			expect(persistSpy).toHaveBeenCalledTimes(1)
+			expect(result.replies).toHaveLength(1)
+			expect(result.text.toLowerCase()).not.toContain("claim rejected")
+			expect(result.text.toLowerCase()).not.toContain("rejection sent")
+			expect(result.dms).toHaveLength(0)
+			expect(result.patches).toHaveLength(0)
+			expect(result.text).toContain("Could not record claim")
+		} finally {
+			consoleError.mockRestore()
+			persistSpy.mockRestore()
+		}
+	})
+
+	it("reports rejected after the decision is recorded", async () => {
+		const persistSpy = spyOn(
+			claimRequests,
+			"recordClaimDecision"
+		).mockImplementation(async () => {})
+		const consoleError = spyOn(console, "error").mockImplementation(() => {})
+
+		try {
+			const result = await runReject()
+
+			expect(persistSpy).toHaveBeenCalledTimes(1)
+			expect(result.text.toLowerCase()).toContain("claim rejected")
+			expect(result.dms).toHaveLength(1)
+			expect(result.patches).toHaveLength(1)
+		} finally {
+			consoleError.mockRestore()
+			persistSpy.mockRestore()
+		}
+	})
+})

--- a/tests/claimRejectPersist.test.ts
+++ b/tests/claimRejectPersist.test.ts
@@ -1,7 +1,19 @@
-import { type ModalInteraction, serializePayload } from "@buape/carbon"
+import {
+	type Button,
+	type ButtonInteraction,
+	ComponentType,
+	Container,
+	MessageFlags,
+	type Modal,
+	type ModalInteraction,
+	Row,
+	Separator,
+	TextDisplay,
+	serializePayload
+} from "@buape/carbon"
 import { describe, expect, it, spyOn } from "bun:test"
 import * as claimRequests from "../src/data/claimRequests.js"
-import { claimReviewModals } from "../src/server/claimServer.js"
+import { claimReviewComponents, claimReviewModals } from "../src/server/claimServer.js"
 
 const flattenComponents = (component: unknown): Record<string, unknown>[] => {
 	if (!component || typeof component !== "object") {
@@ -63,6 +75,65 @@ const runReject = async () => {
 	return { replies, dms, patches, text: replyText(replies) }
 }
 
+const createReviewFlow = (failRestore = false) => {
+	const replies: unknown[] = []
+	const dms: unknown[] = []
+	const patches: unknown[] = []
+	const edits: ReturnType<typeof serializePayload>[] = []
+	const modals: Modal[] = []
+	const AcceptButton = claimReviewComponents[0].constructor as new (userId: string, guildId: string) => Button
+	const RejectButton = claimReviewComponents[1].constructor as new (userId: string, guildId: string) => Button
+	const initialComponents = [new Container([
+		new TextDisplay("### Clawtributor Claim Request"),
+		new TextDisplay("- User: <@user-1>\n- GitHub: [@applicant](<https://github.com/applicant>)"),
+		new Separator({ divider: true, spacing: "large" }),
+		new TextDisplay("### 3 Most Recent Merged PRs\n- [#1 A change](<https://github.com/example/project/pull/1>)"),
+		new Separator({ divider: true, spacing: "small" }),
+		new Row([new AcceptButton("user-1", "guild-1"), new RejectButton("user-1", "guild-1")])
+	], { accentColor: "#f1c40f", spoiler: true }).serialize()]
+	const message = {
+		id: "review-message-1",
+		channelId: "review-channel-1",
+		rawData: { components: structuredClone(initialComponents) },
+		edit: async (payload: Parameters<typeof serializePayload>[0]) => {
+			const serialized = serializePayload(payload)
+			edits.push(serialized)
+			if (failRestore) throw new Error("Discord message update unavailable")
+			message.rawData.components = structuredClone(serialized.components as typeof initialComponents)
+		}
+	}
+	const interaction = {
+		user: { id: "reviewer-1" },
+		fields: { getText: () => "too few merged PRs" },
+		message,
+		reply: async (payload: unknown) => { replies.push(payload) },
+		showModal: async (modal: Modal) => { modals.push(modal) },
+		client: {
+			fetchUser: async () => ({ send: async (payload: unknown) => { dms.push(payload) } }),
+			rest: {
+				patch: async (_route: string, payload: { body: { components: typeof initialComponents } }) => {
+					patches.push(payload)
+					message.rawData.components = structuredClone(payload.body.components)
+				}
+			}
+		}
+	}
+	const data = { userId: "suser-1", guildId: "sguild-1" }
+	return {
+		replies, dms, patches, edits, modals, message, initialComponents,
+		clickReject: () => claimReviewComponents[1].run(interaction as unknown as ButtonInteraction, data),
+		submitReject: () => modals.at(-1)!.run(interaction as unknown as ModalInteraction, data),
+		buttons: () => message.rawData.components
+			.flatMap(flattenComponents)
+			.filter(component => component.type === ComponentType.Button),
+		cardText: () => message.rawData.components
+			.flatMap(flattenComponents)
+			.map(component => component.content)
+			.filter(content => typeof content === "string")
+			.join("\n")
+	}
+}
+
 describe("claim review reject persist", () => {
 	it("does not report rejected when decision persist fails", async () => {
 		const persistSpy = spyOn(
@@ -103,6 +174,88 @@ describe("claim review reject persist", () => {
 			expect(result.text.toLowerCase()).toContain("claim rejected")
 			expect(result.dms).toHaveLength(1)
 			expect(result.patches).toHaveLength(1)
+		} finally {
+			consoleError.mockRestore()
+			persistSpy.mockRestore()
+		}
+	})
+
+	it("restores the complete review card and permits a button-to-modal retry", async () => {
+		const persistSpy = spyOn(claimRequests, "recordClaimDecision")
+			.mockImplementationOnce(async () => { throw new Error("database unavailable") })
+			.mockImplementation(async () => {})
+		const consoleError = spyOn(console, "error").mockImplementation(() => {})
+		try {
+			const flow = createReviewFlow()
+			await flow.clickReject()
+			expect(flow.modals).toHaveLength(1)
+			expect(flow.buttons().every(button => button.disabled)).toBe(true)
+			expect(flow.cardText()).toContain("Rejection in progress")
+			await flow.submitReject()
+
+			expect(persistSpy).toHaveBeenCalledTimes(1)
+			expect(flow.dms).toHaveLength(0)
+			expect(flow.edits).toHaveLength(1)
+			expect(flow.edits[0].allowed_mentions).toEqual({ parse: [] })
+			expect(flow.edits[0].flags).toBe(MessageFlags.IsComponentsV2)
+			expect(flow.message.rawData.components).toEqual(flow.initialComponents)
+			expect(flow.buttons().every(button => !button.disabled)).toBe(true)
+			expect(flow.cardText()).not.toContain("Rejection in progress")
+			expect(replyText(flow.replies)).toContain("review buttons have been restored")
+
+			await flow.clickReject()
+			expect(flow.modals).toHaveLength(2)
+			expect(flow.cardText().match(/Rejection in progress/g)).toHaveLength(1)
+			await flow.submitReject()
+			expect(persistSpy).toHaveBeenCalledTimes(2)
+			expect(flow.dms).toHaveLength(1)
+			expect(flow.buttons().every(button => button.disabled)).toBe(true)
+			expect(flow.cardText()).toContain("Rejected by <@reviewer-1>")
+			expect(replyText(flow.replies)).toContain("Claim rejected")
+		} finally {
+			consoleError.mockRestore()
+			persistSpy.mockRestore()
+		}
+	})
+
+	it("reports when Discord cannot restore the review after a failed save", async () => {
+		const persistSpy = spyOn(claimRequests, "recordClaimDecision").mockImplementation(async () => {
+			throw new Error("database unavailable")
+		})
+		const consoleError = spyOn(console, "error").mockImplementation(() => {})
+		try {
+			const flow = createReviewFlow(true)
+			await flow.clickReject()
+			await flow.submitReject()
+			expect(flow.edits).toHaveLength(1)
+			expect(flow.dms).toHaveLength(0)
+			expect(flow.patches).toHaveLength(1)
+			expect(flow.buttons().every(button => button.disabled)).toBe(true)
+			expect(flow.cardText()).toContain("Rejection in progress")
+			expect(replyText(flow.replies)).toContain("could not be reopened automatically")
+			expect(replyText(flow.replies)).not.toContain("review buttons have been restored")
+			expect(replyText(flow.replies)).not.toContain("Claim rejected")
+		} finally {
+			consoleError.mockRestore()
+			persistSpy.mockRestore()
+		}
+	})
+
+	it("preserves an unfamiliar review card instead of dropping its content", async () => {
+		const persistSpy = spyOn(claimRequests, "recordClaimDecision").mockImplementation(async () => {
+			throw new Error("database unavailable")
+		})
+		const consoleError = spyOn(console, "error").mockImplementation(() => {})
+		try {
+			const flow = createReviewFlow()
+			await flow.clickReject()
+			flow.message.rawData.components[0].components.push(new TextDisplay("Another review update").serialize())
+			const before = structuredClone(flow.message.rawData.components)
+			await flow.submitReject()
+			expect(flow.edits).toHaveLength(0)
+			expect(flow.dms).toHaveLength(0)
+			expect(flow.message.rawData.components).toEqual(before)
+			expect(replyText(flow.replies)).toContain("could not be reopened automatically")
 		} finally {
 			consoleError.mockRestore()
 			persistSpy.mockRestore()


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where rejecting a Clawtributor claim notified the applicant and reported success even when saving the decision failed. The claim stayed pending while the review controls became unusable.

## Why This Change Was Made

Rejection now stops when persistence fails, sends no applicant notification, and restores the original review content with enabled Accept and Reject buttons. The restored card removes the in-progress footer and suppresses mentions. If Discord cannot update the message, or its structure is unfamiliar, the reviewer receives an accurate manual-recovery error.

## User Impact

Reviewers can retry a failed save without leaving the claim stuck. Applicants receive a rejection notification only after the decision is saved. Acceptance is handled separately by #33.

## Evidence

- Seven focused tests pass, including claim storage coverage and the full button-to-modal failure/retry sequence, failed message restoration, and unfamiliar-card preservation.
- A local Miniflare D1 probe used the production writer and a SQLite trigger to force a write failure: the claim stayed submitted, no DM was sent, and the buttons reopened. Removing the trigger and retrying recorded rejection and sent exactly one DM. Discord calls were intercepted locally.
- Combined with main and #33: nine focused tests and typecheck pass. Independent source review found no blocking findings.
- [Full CI](https://github.com/openclaw/hermit/actions/runs/34280687658) covers frozen installs, Worker and forwarder typechecks, a dry-run build, and the full suite.
